### PR TITLE
Replace is with ===

### DIFF
--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -149,7 +149,7 @@ peekchar(s::IOStream) = begin
 end
 
 eof(io::IO) = Base.eof(io)
-eof(c) = is(c, EOF_CHAR)
+eof(c) = c === EOF_CHAR
 
 readchar(io::IO) = eof(io) ? EOF_CHAR : read(io, Char)
 takechar(io::IO) = (readchar(io); io)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using PimpMyREPL.Tokenize
+using OhMyREPL.Tokenize
 using Base.Test
 
 include("../benchmark/lex_base.jl")


### PR DESCRIPTION
`is` is now deprecated on julia-0.6, https://github.com/JuliaLang/julia/pull/18978.
