### PR TITLE
fix methods of iterator interface

### DIFF
--- a/src/lexer.jl
+++ b/src/lexer.jl
@@ -47,10 +47,10 @@ Returns an `Iterable` containing the tokenized input. Can be reverted by e.g.
 tokenize(x) = Lexer(x)
 
 # Iterator interface
-Base.iteratorsize(::Lexer) = Base.SizeUnknown()
-Base.iteratoreltype(::Lexer) = Base.HasEltype()
+Base.iteratorsize{IO_t}(::Type{Lexer{IO_t}}) = Base.SizeUnknown()
+Base.iteratoreltype{IO_t}(::Type{Lexer{IO_t}}) = Base.HasEltype()
 
-Base.eltype(::Lexer) = Token
+Base.eltype{IO_t}(::Type{Lexer{IO_t}}) = Token
 
 function Base.start(l::Lexer)
     seekstart(l)


### PR DESCRIPTION
This fixes method definitions of iterator interface. Precisely speaking, the current code won't cause any technical problem because some fallback methods are defined for convenience, but the proposed code is a recommended way to define iterators.

```
help?> eltype
search: eltype fieldtype

  eltype(type)

  Determine the type of the elements generated by iterating a collection of the given type. For associative collection types, this
  will be a Pair{KeyType,ValType}. The definition eltype(x) = eltype(typeof(x)) is provided for convenience so that instances can be
  passed instead of types. However the form that accepts a type argument should be defined for new types.
```