### PR TITLE
fix ishex

### DIFF
--- a/src/lexer.jl
+++ b/src/lexer.jl
@@ -17,7 +17,7 @@ macro debug(ex)
     return :()
 end
 
-ishex(c::Char) =  isdigit(c) || ('a' <= c <= 'f')
+ishex(c::Char) = isdigit(c) || ('a' <= c <= 'f') || ('A' <= c <= 'F')
 iswhitespace(c::Char) = Base.UTF8proc.isspace(c)
 
 type Lexer{IO_t <: Union{IO, AbstractString}}


### PR DESCRIPTION
This fixes the behavior of `ishex` defined in the module.

master:
```

julia> tokenize("0xdeadBeef") |> collect
3-element Array{Tokenize.Tokens.Token,1}:
 1,1-1,6:   INTEGER     "0xdead"
 1,7-1,10:   IDENTIFIER "Beef"
 1,11-1,10:   ENDMARKER ""

```

this PR:
```
julia> tokenize("0xdeadBeef") |> collect
2-element Array{Tokenize.Tokens.Token,1}:
 1,1-1,10:   INTEGER    "0xdeadBeef"
 1,11-1,10:   ENDMARKER ""

```