### PR TITLE
restructure operators inline with parser

### DIFF
--- a/src/lexer.jl
+++ b/src/lexer.jl
@@ -385,12 +385,10 @@ function lex_greater(l::Lexer)
             else # >>>?, ? not a =
                 return emit(l, Tokens.UNSIGNED_BITSHIFT)
             end
-        else # >>?
-            if accept(l, '=') # >>=
-                return emit(l, Tokens.RBITSHIFT_EQ)
-            else accept(l, iswhitespace) # '>> '
-                return emit(l, Tokens.RBITSHIFT)
-            end
+        elseif accept(l, '=') # >>=
+            return emit(l, Tokens.RBITSHIFT_EQ)
+        else # '>>'
+            return emit(l, Tokens.RBITSHIFT)
         end
     elseif accept(l, '=') # >=
         return emit(l, Tokens.GREATER_EQ)

--- a/src/lexer.jl
+++ b/src/lexer.jl
@@ -310,12 +310,12 @@ function next_token(l::Lexer)
     elseif c == '('; return emit(l, Tokens.LPAREN)
     elseif c == ')'; return emit(l, Tokens.RPAREN)
     elseif c == ','; return emit(l, Tokens.COMMA)
-    elseif c == '*'; return emit(l, Tokens.STAR)
+    elseif c == '*'; return lex_star(l);
+    elseif c == '^'; return lex_circumflex(l);
     elseif c == '@'; return emit(l, Tokens.AT_SIGN)
     elseif c == '?'; return emit(l, Tokens.CONDITIONAL)
-    elseif c == '$'; return emit(l, Tokens.EX_OR)
+    elseif c == '$'; return lex_xor(l);
     elseif c == '~'; return emit(l, Tokens.APPROX)
-    elseif c == '\\'; return emit(l, Tokens.BACKSLASH)
     elseif c == '#'; return lex_comment(l)
     elseif c == '='; return lex_equal(l)
     elseif c == '!'; return lex_exclaim(l)
@@ -324,10 +324,12 @@ function next_token(l::Lexer)
     elseif c == ':'; return lex_colon(l)
     elseif c == '|'; return lex_bar(l)
     elseif c == '&'; return lex_amper(l)
-    elseif c == '\'';return lex_prime(l)
+    elseif c == '\''; return lex_prime(l)
+    elseif c == '÷'; return lex_division(l)    
     elseif c == '"'; return lex_quote(l);
     elseif c == '%'; return lex_percent(l);
     elseif c == '/'; return lex_forwardslash(l);
+    elseif c == '\\'; return lex_backslash(l);
     elseif c == '.'; return lex_dot(l);
     elseif c == '+'; return lex_plus(l);
     elseif c == '-'; return lex_minus(l);
@@ -394,6 +396,8 @@ function lex_greater(l::Lexer)
         end
     elseif accept(l, '=') # >=
         return emit(l, Tokens.GREATER_EQ)
+    elseif accept(l, ':') # >:
+        return emit(l, Tokens.GREATER_COLON)
     else  # '>'
         return emit(l, Tokens.GREATER)
     end
@@ -437,9 +441,11 @@ end
 # Lex a colon, a ':' has been consumed
 function lex_colon(l::Lexer)
     if accept(l, ':') # '::'
-        emit(l, Tokens.DECLARATION)
+        return emit(l, Tokens.DECLARATION)
+    elseif accept(l, '=') # ':='
+        return emit(l, Tokens.COLON_EQ)
     else
-        emit(l, Tokens.COLON)
+        return emit(l, Tokens.COLON)
     end
 end
 
@@ -476,13 +482,55 @@ function lex_bar(l::Lexer)
 end
 
 function lex_plus(l::Lexer)
-    accept(l, '+') && return emit(l, Tokens.PLUSPLUS)
+    if accept(l, '+')
+        return emit(l, Tokens.PLUSPLUS)
+    elseif accept(l, '=')
+        return emit(l, Tokens.PLUS_EQ)
+    end
     return emit(l, Tokens.PLUS)
 end
 
 function lex_minus(l::Lexer)
-    accept(l, '-') && return emit_error(l) # "--" is an invalid operator
+    if accept(l, '-')
+        if accept(l, '>')
+            return emit(l, Tokens.RIGHT_ARROW)
+        else
+            return emit_error(l) # "--" is an invalid operator
+        end
+    elseif accept(l, '=')
+        return emit(l, Tokens.MINUS_EQ)
+    end
     return emit(l, Tokens.MINUS)
+end
+
+function lex_star(l::Lexer)
+    if accept(l, '*')
+        return emit_error(l) # "**" is an invalid operator use ^
+    elseif accept(l, '=')
+        return emit(l, Tokens.STAR_EQ)
+    end
+    return emit(l, Tokens.STAR)
+end
+
+function lex_circumflex(l::Lexer)
+    if accept(l, '=')
+        return emit(l, Tokens.CIRCUMFLEX_EQ)
+    end
+    return emit(l, Tokens.CIRCUMFLEX_ACCENT)
+end
+
+function lex_division(l::Lexer)
+    if accept(l, '=')
+        return emit(l, Tokens.DIVISION_EQ)
+    end
+    return emit(l, Tokens.DIVISION_SIGN)
+end
+
+function lex_xor(l::Lexer)
+    if accept(l, '=')
+        return emit(l, Tokens.EX_OR_EQ)
+    end
+    return emit(l, Tokens.EX_OR)
 end
 
 
@@ -638,6 +686,13 @@ function lex_forwardslash(l::Lexer)
     else
         return emit(l, Tokens.FWD_SLASH)
     end
+end
+
+function lex_backslash(l::Lexer)
+    if accept(l, '=')
+        return emit(l, Tokens.BACKSLASH_EQ)
+    end
+    return emit(l, Tokens.BACKSLASH)
 end
 
 # TODO .op

--- a/src/token_kinds.jl
+++ b/src/token_kinds.jl
@@ -38,71 +38,48 @@
 
     begin_ops,
         OP, # general
-        STAR,  # *
-        PLUS, # +
-        MINUS, # -
-        PLUSPLUS, # ++
-        BACKSLASH, # \
-        NOT, # !
-        APPROX, # ~
 
-        DECLARATION, # ::
-        COLON, # :
-        PRIME, # '
-
-        DOT,# .
-        DDOT, # ..
-        DDDOT, # ...
-
-        LAZY_OR, # ||
-        LAZY_AND, # &&
-        OR, # |
-        AND, # &
-        CONDITIONAL, # ?
-        REM, # %
-        FWD_SLASH, # /
-        FWDFWD_SLASH, # //
-        TRANSPOSE, # .'
-        ISSUBTYPE, # <:
-        EX_OR, # $
-
-        GREATER, # >
-        LESS, # <
-        NOT_EQ, # !=
-        NOT_IS, # !==
-
-        LPIPE, # |>
-        RPIPE, # <|
-
-        begin_bitshifts,
-          LBITSHIFT, # <<
-          RBITSHIFT, # >>
-          UNSIGNED_BITSHIFT, # >>>
-        end_bitshifts,
-
+        # Level 1
         begin_assignments,
-          EQ, # =
-          EQEQ, # ==
-          EQEQEQ, # ===
-          PAIR_ARROW, # =>
-          GREATER_EQ, # >=
-          LESS_EQ, # <=
-          RBITSHIFT_EQ, # >>=
-          UNSIGNED_BITSHIFT_EQ, # >>>=
-          LBITSHIFT_EQ, # <<=
-          OR_EQ, # |=
-          AND_EQ, # &=
-          REM_EQ, # %=
-          FWD_SLASH_EQ, # /=
-          FWDFWD_SLASH_EQ, # //=
+            EQ, # =
+            PLUS_EQ, # +=
+            MINUS_EQ, # -=
+            STAR_EQ, # *=
+            FWD_SLASH_EQ, # /=
+            FWDFWD_SLASH_EQ, # //=
+            OR_EQ, # |=
+            CIRCUMFLEX_EQ, # ^=
+            DIVISION_EQ, # ÷=
+            REM_EQ, # %=
+            LBITSHIFT_EQ, # <<=
+            RBITSHIFT_EQ, # >>=
+            UNSIGNED_BITSHIFT_EQ, # >>>=
+            BACKSLASH_EQ, # \=
+            AND_EQ, # &=
+            COLON_EQ, # :=
+            PAIR_ARROW, # =>
+            APPROX, # ~
+            EX_OR_EQ, # $=
         end_assignments,
 
-        begin_unicode_ops,
-            DIVISION_SIGN, # ÷
-            NOT_SIGN, # ¬
-            SQUARE_ROOT, # √
-            CUBE_ROOT, # ∛
-            QUAD_ROOT, # ∜
+        # Level 2
+        begin_conditional,
+            CONDITIONAL, # ?
+        end_conditional,
+
+        # Level 3
+        begin_lazyor,
+            LAZY_OR, # ||
+        end_lazyor,
+
+        # Level 4
+        begin_lazyand,
+            LAZY_AND, # &&
+        end_lazyand,
+
+        # Level 5
+        begin_arrow,
+            RIGHT_ARROW, # -->
             LEFTWARDS_ARROW, # ←
             RIGHTWARDS_ARROW, # →
             LEFT_RIGHT_ARROW, # ↔
@@ -218,10 +195,25 @@
             RIGHTWARDS_ARROW_ABOVE_REVERSE_TILDE_OPERATOR, # ⭌
             HALFWIDTH_LEFTWARDS_ARROW, # ￩
             HALFWIDTH_RIGHTWARDS_ARROW, # ￫
+        end_arrow,
+
+
+        # Level 6
+        begin_comparison,
+            ISSUBTYPE, # <:
+            GREATER_COLON, # >:
+            GREATER, # >
+            LESS, # <
+            GREATER_EQ, # >=
             GREATER_THAN_OR_EQUAL_TO, # ≥
+            LESS_EQ, # <=
             LESS_THAN_OR_EQUAL_TO, # ≤
+            EQEQ, # ==
+            EQEQEQ, # ===
             IDENTICAL_TO, # ≡
+            NOT_EQ, # !=
             NOT_EQUAL_TO, # ≠
+            NOT_IS, # !==
             NOT_IDENTICAL_TO, # ≢
             ELEMENT_OF, # ∈
             NOT_AN_ELEMENT_OF, # ∉
@@ -493,6 +485,26 @@
             DOUBLE_LINE_SLANTED_GREATER_THAN_OR_EQUAL_TO, # ⫺
             RIGHT_TACK, # ⊢
             LEFT_TACK, # ⊣
+        end_comparison,
+
+        # Level 7
+        begin_pipe,
+            LPIPE, # |>
+            RPIPE, # <|
+        end_pipe,
+
+        # Level 8
+        begin_colon,
+            COLON, # :
+            DDOT, # ..
+        end_colon,
+
+        # Level 9
+        begin_plus,
+            EX_OR, # $
+            PLUS, # +
+            MINUS, # -
+            PLUSPLUS, # ++
             CIRCLED_PLUS, # ⊕
             CIRCLED_MINUS, # ⊖
             SQUARED_PLUS, # ⊞
@@ -546,8 +558,26 @@
             SMALL_VEE_WITH_UNDERBAR, # ⩡
             LOGICAL_OR_WITH_DOUBLE_OVERBAR, # ⩢
             LOGICAL_OR_WITH_DOUBLE_UNDERBAR, # ⩣
+        end_plus,
+
+        # Level 10
+        begin_bitshifts,
+          LBITSHIFT, # <<
+          RBITSHIFT, # >>
+          UNSIGNED_BITSHIFT, # >>>
+        end_bitshifts,
+
+        # Level 11
+        begin_times,
+            STAR,  # *
+            FWD_SLASH, # /
+            DIVISION_SIGN, # ÷
+            REM, # %
+            UNICODE_DOT, # ⋅
             RING_OPERATOR, # ∘
             MULTIPLICATION_SIGN, # ×
+            BACKSLASH, # \
+            AND, # &
             INTERSECTION, # ∩
             LOGICAL_AND, # ∧
             CIRCLED_TIMES, # ⊗
@@ -610,6 +640,15 @@
             LOGICAL_AND_WITH_DOUBLE_UNDERBAR, # ⩠
             TRANSVERSAL_INTERSECTION, # ⫛
             MULTISET_MULTIPLICATION, # ⊍
+        end_times,
+
+        # Level 12
+        begin_rational,
+            FWDFWD_SLASH, # //
+        end_rational,
+
+        # Level 13
+        begin_power,
             CIRCUMFLEX_ACCENT, # ^
             UPWARDS_ARROW, # ↑
             DOWNWARDS_ARROW, # ↓
@@ -641,7 +680,30 @@
             DOWNWARDS_HARPOON_WITH_BARB_LEFT_BESIDE_UPWARDS_HARPOON_WITH_BARB_RIGHT, # ⥯
             HALFWIDTH_UPWARDS_ARROW, # ￪
             HALFWIDTH_DOWNWARDS_ARROW, # ￬
-            UNICODE_DOT, # ⋅
+        end_power,
+        
+        # Level 14
+        begin_decl,
+            DECLARATION, # ::
+        end_decl,
+
+        # Level 15
+        begin_dot,
+            DOT,# .
+        end_dot,
+
+        NOT, # !
+        PRIME, # '
+        DDDOT, # ...
+        OR, # |
+        TRANSPOSE, # .'
+        
+
+        begin_unicode_ops,
+            NOT_SIGN, # ¬
+            SQUARE_ROOT, # √
+            CUBE_ROOT, # ∛
+            QUAD_ROOT, # ∜
         end_unicode_ops,
     end_ops,
 )

--- a/test/lexer.jl
+++ b/test/lexer.jl
@@ -132,3 +132,6 @@ end
 
 # test #5
 @test Tokens.kind.(collect(tokenize("1.23..3.21"))) == [T.FLOAT,T.OP,T.FLOAT,T.ENDMARKER]
+
+# issue #17
+@test collect(tokenize(">> "))[1].val==">>"

--- a/test/lexer.jl
+++ b/test/lexer.jl
@@ -132,3 +132,16 @@ end
 
 # test #5
 @test Tokens.kind.(collect(tokenize("1.23..3.21"))) == [T.FLOAT,T.OP,T.FLOAT,T.ENDMARKER]
+
+
+# test added operators
+@test collect(tokenize("1+=2"))[2].kind == Tokenize.Tokens.PLUS_EQ
+@test collect(tokenize("1-=2"))[2].kind == Tokenize.Tokens.MINUS_EQ
+@test collect(tokenize("1:=2"))[2].kind == Tokenize.Tokens.COLON_EQ
+@test collect(tokenize("1*=2"))[2].kind == Tokenize.Tokens.STAR_EQ
+@test collect(tokenize("1^=2"))[2].kind == Tokenize.Tokens.CIRCUMFLEX_EQ
+@test collect(tokenize("1÷=2"))[2].kind == Tokenize.Tokens.DIVISION_EQ
+@test collect(tokenize("1\\=2"))[2].kind == Tokenize.Tokens.BACKSLASH_EQ
+@test collect(tokenize("1\$=2"))[2].kind == Tokenize.Tokens.EX_OR_EQ
+@test collect(tokenize("1-->2"))[2].kind == Tokenize.Tokens.RIGHT_ARROW
+@test collect(tokenize("1>:2"))[2].kind == Tokenize.Tokens.GREATER_COLON


### PR DESCRIPTION
This adds the ordering of operators used in `julia-parser.scm` and `JuliaParser.jl`.

It also adds some missing operators