### PR TITLE
replace Char[] w IObuffer

### DIFF
--- a/src/lexer.jl
+++ b/src/lexer.jl
@@ -274,8 +274,7 @@ end
 Returns all characters since the start of the current `Token` as a `String`.
 """
 function extract_tokenstring(l::Lexer)
-    cs = Char[]
-    sizehint!(cs, position(l) - startpos(l))
+    cs = IOBuffer()
     curr_pos = position(l)
     seek2startpos!(l)
 
@@ -286,9 +285,9 @@ function extract_tokenstring(l::Lexer)
             l.current_row += 1
             l.current_col = 1
          end
-        push!(cs, c)
+        write(cs, c)
     end
-    str = String(cs)
+    str = String(take!(cs))
     return str
 end
 

--- a/src/lexer.jl
+++ b/src/lexer.jl
@@ -1,6 +1,7 @@
 module Lexers
 
 include("utilities.jl")
+global const charstore = IOBuffer()
 
 using Compat
 import Compat.String
@@ -274,7 +275,7 @@ end
 Returns all characters since the start of the current `Token` as a `String`.
 """
 function extract_tokenstring(l::Lexer)
-    cs = IOBuffer()
+    global charstore
     curr_pos = position(l)
     seek2startpos!(l)
 
@@ -285,9 +286,9 @@ function extract_tokenstring(l::Lexer)
             l.current_row += 1
             l.current_col = 1
          end
-        write(cs, c)
+        write(charstore, c)
     end
-    str = String(take!(cs))
+    str = String(take!(charstore))
     return str
 end
 


### PR DESCRIPTION
This seems to give a considerable speedup  (5-10% in time/allocation) in my own benchmark making intensive use of `Tokenize` though has no discernible impact on the timings from `Pkg.test("Tokenize")`