### PR TITLE
fix lex_bool

### DIFF
--- a/src/lexer.jl
+++ b/src/lexer.jl
@@ -549,9 +549,19 @@ end
 function lex_bool(l::Lexer)
     str = lex_identifier(l)
     if str.val=="true"
-        return emit(l, Tokens.TRUE, "true")
+        l.last_token = Tokens.TRUE
+        start_token!(l)
+        return Token(Tokens.TRUE, str.startpos,
+                str.endpos,
+                str.startbyte, str.endbyte,
+                str.val, str.token_error)
     elseif str.val == "false"
-        return emit(l, Tokens.FALSE, "false")
+        l.last_token = Tokens.FALSE
+        start_token!(l)
+        return Token(Tokens.FALSE, str.startpos,
+                str.endpos,
+                str.startbyte, str.endbyte,
+                str.val, str.token_error)
     else
         return str
     end

--- a/test/lexer.jl
+++ b/test/lexer.jl
@@ -137,6 +137,8 @@ end # testset
         @test untokenize(tokenize(str)) == str
         @test_throws ArgumentError untokenize("blabla")
     end
+
+    @test all((t.endbyte - t.startbyte)==sizeof(t.val) for t in tokenize(str))
 end # testset
 
 @testset "issue 5, '..'" begin


### PR DESCRIPTION
I introduced this bug in an earlier PR which didn't emit correct byte/line positioning for bools.

I've also added a test for `(t.endbyte - t.startbyte) == sizeof(t.val)`