### PR TITLE
Fix lex i

### DIFF
--- a/src/lexer.jl
+++ b/src/lexer.jl
@@ -538,9 +538,19 @@ end
 function lex_i(l::Lexer)
     str = lex_identifier(l)
     if str.val=="in"
-        return emit(l, Tokens.IN, "in")
+        l.last_token = Tokens.IN
+        start_token!(l)
+        return Token(Tokens.IN, str.startpos,
+                str.endpos,
+                str.startbyte, str.endbyte,
+                str.val, str.token_error)
     elseif (VERSION >= v"0.6.0-dev.1471" && str.val == "isa")
-        return emit(l, Tokens.ISA, "isa")
+        l.last_token = Tokens.ISA
+        start_token!(l)
+        return Token(Tokens.ISA, str.startpos,
+                str.endpos,
+                str.startbyte, str.endbyte,
+                str.val, str.token_error)
     else
         return str
     end

--- a/test/lexer.jl
+++ b/test/lexer.jl
@@ -228,3 +228,8 @@ end
     @test all(x->x.val=="'", collect(tokenize("'''"))[1:3])
     @test all(x->x.val=="'", collect(tokenize("''''"))[1:4])
 end
+
+@testset "in/isa bytelength"
+    t = collect(tokenize("x in y"))[3]
+    @test t.endbyte-t.startbyte==2
+end

--- a/test/lexer.jl
+++ b/test/lexer.jl
@@ -229,7 +229,7 @@ end
     @test all(x->x.val=="'", collect(tokenize("''''"))[1:4])
 end
 
-@testset "in/isa bytelength"
+@testset "in/isa bytelength" begin
     t = collect(tokenize("x in y"))[3]
     @test t.endbyte-t.startbyte==2
 end


### PR DESCRIPTION
The same mistake was made as with bools, fixes byte lengths for `in` and `isa`