### PR TITLE
add invisble keywords

### DIFF
--- a/src/token_kinds.jl
+++ b/src/token_kinds.jl
@@ -31,6 +31,7 @@
     begin_invisble_keywords,
         BLOCK,
         CALL,
+        CCALL,
         COMPARISON,
         COMPREHENSION,
         CURLY,

--- a/src/token_kinds.jl
+++ b/src/token_kinds.jl
@@ -28,6 +28,25 @@
         END,  
     end_keywords,
 
+    begin_invisble_keywords,
+        BLOCK,
+        CALL,
+        COMPARISON,
+        COMPREHENSION,
+        CURLY,
+        GENERATOR,
+        KW,
+        LINE,
+        MACROCALL,
+        PARAMETERS,
+        REF,
+        TOPLEVEL,
+        TUPLE,
+        TYPED_COMPREHENSION,
+        VCAT,
+        VECT,
+    end_invisble_keywords,
+
     begin_literal,
         LITERAL, # general
         INTEGER, # 4


### PR DESCRIPTION
Won't impact on `Tokenize` behaviour but allows inferred syntax elements to be represented by the same type system as other keywords.