### PR TITLE
recognise STRINGs w/ enclosed interpolations

### DIFF
--- a/src/lexer.jl
+++ b/src/lexer.jl
@@ -7,7 +7,7 @@ using Compat
 import Compat.String
 
 import ..Tokens
-import ..Tokens: Token, Kind, TokenError, UNICODE_OPS
+import ..Tokens: Token, Kind, TokenError, UNICODE_OPS, EMPTY_TOKEN
 
 import ..Tokens: FUNCTION, ABSTRACT, IDENTIFIER, BAREMODULE, BEGIN, BITSTYPE, BREAK, CATCH, CONST, CONTINUE,
                  DO, ELSE, ELSEIF, END, EXPORT, FALSE, FINALLY, FOR, FUNCTION, GLOBAL, LET, LOCAL, IF, IMMUTABLE,
@@ -641,16 +641,16 @@ function lex_quote(l::Lexer, doemit=true)
     if accept(l, '"') # ""
         if accept(l, '"') # """
             if read_string(l, Tokens.TRIPLE_STRING)
-                return doemit ? emit(l, Tokens.TRIPLE_STRING) : nothing
+                return doemit ? emit(l, Tokens.TRIPLE_STRING) : EMPTY_TOKEN
             else
                 return emit_error(l, Tokens.EOF_STRING)
             end
         else # empty string
-            return doemit ?  emit(l, Tokens.STRING) : nothing
+            return doemit ?  emit(l, Tokens.STRING) : EMPTY_TOKEN
         end
     else # "?, ? != '"'
         if read_string(l, Tokens.STRING)
-            return doemit ?  emit(l, Tokens.STRING) : nothing
+            return doemit ?  emit(l, Tokens.STRING) : EMPTY_TOKEN
         else
             return emit_error(l, Tokens.EOF_STRING)
         end

--- a/src/lexer.jl
+++ b/src/lexer.jl
@@ -677,7 +677,15 @@ function read_string(l::Lexer, kind::Tokens.Kind)
         end
         if c == '$'
             c = readchar(l)
-            if c == '('
+            if c == '"'
+                if kind == Tokens.STRING
+                    return true
+                else
+                    if accept(l, "\"") && accept(l, "\"")
+                        return true
+                    end
+                end
+            elseif c == '('
                 o = 1
                 while o > 0
                     c = readchar(l)

--- a/src/token.jl
+++ b/src/token.jl
@@ -61,6 +61,8 @@ function Token(kind::Kind, startposition::Tuple{Int, Int}, endposition::Tuple{In
 end
 Token() = Token(ERROR, (0,0), (0,0), 0, 0, "", UNKNOWN)
 
+const EMPTY_TOKEN = Token()
+
 function kind(t::Token)
     isoperator(t.kind) && return OP
     iskeyword(t.kind) && return KEYWORD

--- a/test/lexer.jl
+++ b/test/lexer.jl
@@ -302,4 +302,6 @@ end
     ts = collect(tokenize(""""str: \$(g("str: \$(h("str"))"))" """))
     @test length(ts)==3
     @test ts[1].kind == Tokens.STRING
+    ts = collect(tokenize("""\"\$\""""))
+    @test ts[1].kind == Tokens.STRING 
 end

--- a/test/lexer.jl
+++ b/test/lexer.jl
@@ -297,3 +297,9 @@ end
     show(io, collect(tokenize("\"abc\nd\"ef"))[1])
     @test String(take!(io)) == "1,1-2,2          STRING         \"\\\"abc\\nd\\\"\""
 end
+
+@testset "interpolation" begin
+    ts = collect(tokenize(""""str: \$(g("str: \$(h("str"))"))" """))
+    @test length(ts)==3
+    @test ts[1].kind == Tokens.STRING
+end


### PR DESCRIPTION
This should skip over interpolated regions, though I'm not quite sure if this will behave identically to `julia-parser.scm` when there are syntax errors inside the enclosed code.