### PR TITLE
Fix lexing of identifiers followed by not_eq

### DIFF
--- a/src/lexer.jl
+++ b/src/lexer.jl
@@ -765,6 +765,8 @@ function readrest(l, c)
         if c == '!' && peekchar(l) == '='
             backup!(l)
             break
+        elseif !is_identifier_char(peekchar(l))
+            break
         end
         c = readchar(l)
     end
@@ -773,7 +775,7 @@ function readrest(l, c)
 end
 
 
-function _doret(c, l)
+function _doret(l, c)
     if !is_identifier_char(c)
         backup!(l)
         return emit(l, IDENTIFIER)
@@ -796,7 +798,7 @@ function lex_identifier(l, c)
         elseif c == 'r'
             return tryread(l, ('e', 'a', 'k'), BREAK)
         else
-            return _doret(c, l)
+            return _doret(l, c)
         end
     elseif c == 'c'
         c = readchar(l)
@@ -811,13 +813,13 @@ function lex_identifier(l, c)
                 elseif c == 't'
                     return tryread(l, ('i', 'n', 'u', 'e'), CONTINUE)
                 else
-                    return _doret(c, l)
+                    return _doret(l, c)
                 end
             else
-                return _doret(c, l)
+                return _doret(l, c)
             end
         else
-            return _doret(c, l)
+            return _doret(l, c)
         end
     elseif c == 'd'
         return tryread(l, ('o'), DO)
@@ -835,20 +837,20 @@ function lex_identifier(l, c)
                     elseif c == 'i'
                         return tryread(l, ('f'), ELSEIF)
                     else
-                        return _doret(c, l)
+                        return _doret(l, c)
                     end
                 else
-                    return _doret(c, l)
+                    return _doret(l, c)
                 end
             else
-                return _doret(c, l)
+                return _doret(l, c)
             end
         elseif c == 'n'
             return tryread(l, ('d'), END)
         elseif c == 'x'
             return tryread(l, ('p', 'o', 'r', 't'), EXPORT)
         else
-            return _doret(c, l)
+            return _doret(l, c)
         end
     elseif c == 'f'
         c = readchar(l)
@@ -861,7 +863,7 @@ function lex_identifier(l, c)
         elseif c == 'u'
             return tryread(l, ('n', 'c', 't', 'i', 'o', 'n'), FUNCTION)
         else
-            return _doret(c, l)
+            return _doret(l, c)
         end
     elseif c == 'g'
         return tryread(l, ('l', 'o', 'b', 'a', 'l'), GLOBAL)
@@ -893,19 +895,19 @@ function lex_identifier(l, c)
                             elseif c == 'a'
                                 return tryread(l, ('l','l'), IMPORTALL)
                             else
-                               return _doret(c, l)
+                               return _doret(l, c)
                             end
                         else
-                            return _doret(c, l)
+                            return _doret(l, c)
                         end
                     else
-                        return _doret(c, l)
+                        return _doret(l, c)
                     end
                 else
-                    return _doret(c, l)
+                    return _doret(l, c)
                 end
             else
-                return _doret(c, l)
+                return _doret(l, c)
             end
         elseif c == 'n'
             c = readchar(l)
@@ -918,7 +920,7 @@ function lex_identifier(l, c)
         elseif (@static VERSION >= v"0.6.0-dev.1471" ? true : false) && c == 's'
             return tryread(l, ('a'), ISA)
         else
-            return _doret(c, l)
+            return _doret(l, c)
         end
     elseif c == 'l'
         c = readchar(l)
@@ -927,7 +929,7 @@ function lex_identifier(l, c)
         elseif c == 'o'
             return tryread(l, ('c', 'a', 'l'), LOCAL)
         else
-            return _doret(c, l)
+            return _doret(l, c)
         end
     elseif c == 'm'
         c = readchar(l)
@@ -936,7 +938,7 @@ function lex_identifier(l, c)
         elseif c == 'o'
             return tryread(l, ('d', 'u', 'l', 'e'), MODULE)
         else
-            return _doret(c, l)
+            return _doret(l, c)
         end
     elseif c == 'q'
         return tryread(l, ('u', 'o', 't', 'e'), QUOTE)
@@ -954,10 +956,10 @@ function lex_identifier(l, c)
                     backup!(l)
                     return emit(l, TRY)
                 else
-                    return _doret(c, l)
+                    return _doret(l, c)
                 end
             else
-                return _doret(c, l)
+                return _doret(l, c)
             end
         elseif c == 'y'
             c = readchar(l)
@@ -971,23 +973,23 @@ function lex_identifier(l, c)
                     elseif c == 'a'
                         return tryread(l, ('l', 'i', 'a', 's'), TYPEALIAS)
                     else
-                        return _doret(c, l)
+                        return _doret(l, c)
                     end
                 else
-                    return _doret(c, l)
+                    return _doret(l, c)
                 end
             else
-                return _doret(c, l)
+                return _doret(l, c)
             end
         else
-            return _doret(c, l)
+            return _doret(l, c)
         end
     elseif c == 'u'
         return tryread(l, ('s', 'i', 'n', 'g'), USING)
     elseif c == 'w'
         return tryread(l, ('h', 'i', 'l', 'e'), WHILE)
     else
-        return _doret(c, l)
+        return _doret(l, c)
     end
 end
 

--- a/src/lexer.jl
+++ b/src/lexer.jl
@@ -743,7 +743,7 @@ function lex_cmd(l::Lexer)
     end
 end
 
-function tryread(l, str, k)
+function tryread(l, str, k, c)
     for s in str
         c = readchar(l)
         if c != s
@@ -786,32 +786,32 @@ end
 
 function lex_identifier(l, c)
     if c == 'a'
-        return tryread(l, ('b', 's', 't', 'r', 'a', 'c', 't'), ABSTRACT)
+        return tryread(l, ('b', 's', 't', 'r', 'a', 'c', 't'), ABSTRACT, c)
     elseif c == 'b'
         c = readchar(l)
         if c == 'a'
-            return tryread(l, ('r', 'e', 'm', 'o', 'd', 'u', 'l', 'e'), BAREMODULE)
+            return tryread(l, ('r', 'e', 'm', 'o', 'd', 'u', 'l', 'e'), BAREMODULE, c)
         elseif c == 'e'
-            return tryread(l, ('g', 'i', 'n'), BEGIN)
+            return tryread(l, ('g', 'i', 'n'), BEGIN, c)
         elseif c == 'i'
-            return tryread(l, ('t', 's', 't', 'y', 'p', 'e'), BITSTYPE)
+            return tryread(l, ('t', 's', 't', 'y', 'p', 'e'), BITSTYPE, c)
         elseif c == 'r'
-            return tryread(l, ('e', 'a', 'k'), BREAK)
+            return tryread(l, ('e', 'a', 'k'), BREAK, c)
         else
             return _doret(l, c)
         end
     elseif c == 'c'
         c = readchar(l)
         if c == 'a'
-            return tryread(l, ('t', 'c', 'h'), CATCH)
+            return tryread(l, ('t', 'c', 'h'), CATCH, c)
         elseif c == 'o'
             c = readchar(l)
             if c == 'n'
                 c = readchar(l)
                 if c == 's'
-                    return tryread(l, ('t',), CONST)
+                    return tryread(l, ('t',), CONST, c)
                 elseif c == 't'
-                    return tryread(l, ('i', 'n', 'u', 'e'), CONTINUE)
+                    return tryread(l, ('i', 'n', 'u', 'e'), CONTINUE, c)
                 else
                     return _doret(l, c)
                 end
@@ -822,7 +822,7 @@ function lex_identifier(l, c)
             return _doret(l, c)
         end
     elseif c == 'd'
-        return tryread(l, ('o'), DO)
+        return tryread(l, ('o'), DO, c)
     elseif c == 'e'
         c = readchar(l)
         if c == 'l'
@@ -835,7 +835,7 @@ function lex_identifier(l, c)
                         backup!(l)
                         return emit(l, ELSE)
                     elseif c == 'i'
-                        return tryread(l, ('f'), ELSEIF)
+                        return tryread(l, ('f'), ELSEIF ,c)
                     else
                         return _doret(l, c)
                     end
@@ -846,27 +846,27 @@ function lex_identifier(l, c)
                 return _doret(l, c)
             end
         elseif c == 'n'
-            return tryread(l, ('d'), END)
+            return tryread(l, ('d'), END, c)
         elseif c == 'x'
-            return tryread(l, ('p', 'o', 'r', 't'), EXPORT)
+            return tryread(l, ('p', 'o', 'r', 't'), EXPORT, c)
         else
             return _doret(l, c)
         end
     elseif c == 'f'
         c = readchar(l)
         if c == 'a'
-            return tryread(l, ('l', 's', 'e'), FALSE)
+            return tryread(l, ('l', 's', 'e'), FALSE, c)
         elseif c == 'i'
-            return tryread(l, ('n', 'a', 'l', 'l', 'y'), FINALLY)
+            return tryread(l, ('n', 'a', 'l', 'l', 'y'), FINALLY, c)
         elseif c == 'o'
-            return tryread(l, ('r'), FOR)
+            return tryread(l, ('r'), FOR, c)
         elseif c == 'u'
-            return tryread(l, ('n', 'c', 't', 'i', 'o', 'n'), FUNCTION)
+            return tryread(l, ('n', 'c', 't', 'i', 'o', 'n'), FUNCTION, c)
         else
             return _doret(l, c)
         end
     elseif c == 'g'
-        return tryread(l, ('l', 'o', 'b', 'a', 'l'), GLOBAL)
+        return tryread(l, ('l', 'o', 'b', 'a', 'l'), GLOBAL, c)
     elseif c == 'i'
         c = readchar(l)
         if c == 'f'
@@ -880,7 +880,7 @@ function lex_identifier(l, c)
         elseif c == 'm'
             c = readchar(l)
             if c == 'm'
-                return tryread(l, ('u', 't', 'a', 'b', 'l', 'e'), IMMUTABLE)
+                return tryread(l, ('u', 't', 'a', 'b', 'l', 'e'), IMMUTABLE, c)
             elseif c == 'p'
                 c = readchar(l)
                 if c == 'o'
@@ -893,7 +893,7 @@ function lex_identifier(l, c)
                                 backup!(l)
                                 return emit(l, IMPORT)
                             elseif c == 'a'
-                                return tryread(l, ('l','l'), IMPORTALL)
+                                return tryread(l, ('l','l'), IMPORTALL, c)
                             else
                                return _doret(l, c)
                             end
@@ -918,38 +918,38 @@ function lex_identifier(l, c)
                 return readrest(l, c)
             end
         elseif (@static VERSION >= v"0.6.0-dev.1471" ? true : false) && c == 's'
-            return tryread(l, ('a'), ISA)
+            return tryread(l, ('a'), ISA, c)
         else
             return _doret(l, c)
         end
     elseif c == 'l'
         c = readchar(l)
         if c == 'e'
-            return tryread(l, ('t'), LET)
+            return tryread(l, ('t'), LET, c)
         elseif c == 'o'
-            return tryread(l, ('c', 'a', 'l'), LOCAL)
+            return tryread(l, ('c', 'a', 'l'), LOCAL, c)
         else
             return _doret(l, c)
         end
     elseif c == 'm'
         c = readchar(l)
         if c == 'a'
-            return tryread(l, ('c', 'r', 'o'), MACRO)
+            return tryread(l, ('c', 'r', 'o'), MACRO, c)
         elseif c == 'o'
-            return tryread(l, ('d', 'u', 'l', 'e'), MODULE)
+            return tryread(l, ('d', 'u', 'l', 'e'), MODULE, c)
         else
             return _doret(l, c)
         end
     elseif c == 'q'
-        return tryread(l, ('u', 'o', 't', 'e'), QUOTE)
+        return tryread(l, ('u', 'o', 't', 'e'), QUOTE, c)
     elseif c == 'r'
-        return tryread(l, ('e', 't', 'u', 'r', 'n'), RETURN)
+        return tryread(l, ('e', 't', 'u', 'r', 'n'), RETURN, c)
     elseif c == 't'
         c = readchar(l)
         if c == 'r'
             c = readchar(l)
             if c == 'u'
-                return tryread(l, ('e'), TRUE)
+                return tryread(l, ('e'), TRUE, c)
             elseif c == 'y'
                 c = readchar(l)
                 if !is_identifier_char(c)
@@ -971,7 +971,7 @@ function lex_identifier(l, c)
                         backup!(l)
                         return emit(l, TYPE)
                     elseif c == 'a'
-                        return tryread(l, ('l', 'i', 'a', 's'), TYPEALIAS)
+                        return tryread(l, ('l', 'i', 'a', 's'), TYPEALIAS, c)
                     else
                         return _doret(l, c)
                     end
@@ -985,9 +985,9 @@ function lex_identifier(l, c)
             return _doret(l, c)
         end
     elseif c == 'u'
-        return tryread(l, ('s', 'i', 'n', 'g'), USING)
+        return tryread(l, ('s', 'i', 'n', 'g'), USING, c)
     elseif c == 'w'
-        return tryread(l, ('h', 'i', 'l', 'e'), WHILE)
+        return tryread(l, ('h', 'i', 'l', 'e'), WHILE, c)
     else
         return _doret(l, c)
     end

--- a/test/lexer.jl
+++ b/test/lexer.jl
@@ -312,3 +312,7 @@ end
     Base.Test.@inferred Tokenize.Lexers.next_token(l)
 end
 
+@testset "modifying function names (!) followed by operator" begin
+    ts = collect(tokenize("a!="))
+    @test ts[2].king == Tokens.NOT_EQ
+end

--- a/test/lexer.jl
+++ b/test/lexer.jl
@@ -313,6 +313,7 @@ end
 end
 
 @testset "modifying function names (!) followed by operator" begin
-    ts = collect(tokenize("a!="))
-    @test ts[2].king == Tokens.NOT_EQ
+    @test collect(tokenize("a!=b"))[2].kind == Tokens.NOT_EQ
+    @test collect(tokenize("a!!=b"))[2].kind == Tokens.NOT_EQ
+    @test collect(tokenize("!=b"))[1].kind == Tokens.NOT_EQ
 end


### PR DESCRIPTION
Drops trailing `!` of an identifier if followed by `=`