### PR TITLE
fix for underscores in decimal part of floats

### DIFF
--- a/src/lexer.jl
+++ b/src/lexer.jl
@@ -17,8 +17,8 @@ import ..Tokens: FUNCTION, ABSTRACT, IDENTIFIER, BAREMODULE, BEGIN, BITSTYPE, BR
 
 export tokenize
 
-isdigit(c::Char) = Base.isdigit(c) || c == '_'
-ishex(c::Char) = isdigit(c) || ('a' <= c <= 'f') || ('A' <= c <= 'F')
+ishex(c::Char) = isdigit(c) || ('a' <= c <= 'f') || ('A' <= c <= 'F') || c == 
+'_'
 isbinary(c::Char) = c == '0' || c == '1' || c == '_'
 isoctal(c::Char) =  '0' ≤ c ≤ '7' || c == '_'
 iswhitespace(c::Char) = Base.UTF8proc.isspace(c)
@@ -310,8 +310,8 @@ function next_token(l::Lexer)
     elseif c == '+'; return lex_plus(l);
     elseif c == '-'; return lex_minus(l);
     elseif c == '`'; return lex_cmd(l);
-    elseif isdigit(c); return lex_digit(l)
     elseif is_identifier_start_char(c); return lex_identifier(l, c)
+    elseif isdigit(c); return lex_digit(l)
     elseif (k = get(UNICODE_OPS, c, Tokens.ERROR)) != Tokens.ERROR; return emit(l, k)
     else emit_error(l)
     end
@@ -516,12 +516,29 @@ function lex_xor(l::Lexer)
     return emit(l, Tokens.XOR)
 end
 
+function accept_integer(l::Lexer)
+    !isdigit(peekchar(l)) && return false
+    while true
+        if !accept(l, isdigit)
+            if accept(l, '_')
+                if !isdigit(peekchar(l))
+                    backup!(l)
+                    return true
+                end
+            else
+                return true
+            end
+        end
+    end
+end
+
 # A digit has been consumed
 function lex_digit(l::Lexer)
     backup!(l)
     longest, kind = position(l), Tokens.ERROR
 
-    accept_batch(l, isdigit)
+    # accept_batch(l, isdigit)
+    accept_integer(l)
 
     if accept(l, '.')
         if peekchar(l) == '.' # 43.. -> [43, ..]
@@ -540,11 +557,13 @@ function lex_digit(l::Lexer)
             || peekchar(l) == ';'
             || peekchar(l) == '@'
             || peekchar(l) == '`'
-            || peekchar(l) == '"')
+            || peekchar(l) == '"'
+            || eof(l))
             backup!(l)
             return emit(l, Tokens.INTEGER)
         end
-        accept_batch(l, isdigit)
+        # accept_batch(l, isdigit)
+        accept_integer(l)
         if accept(l, '.')
             if peekchar(l) == '.' # 1.23..3.21 is valid
                 backup!(l)
@@ -560,13 +579,13 @@ function lex_digit(l::Lexer)
         end
         if accept(l, "eEf") # 1313.[0-9]*e
             accept(l, "+-")
-            if accept_batch(l, isdigit) && position(l) > longest
+            if accept_integer(l) && position(l) > longest
                 longest, kind = position(l), Tokens.FLOAT
             end
         end
     elseif accept(l, "eEf")
         accept(l, "+-")
-        if accept_batch(l, isdigit) && position(l) > longest
+        if accept_integer(l) && position(l) > longest
             longest, kind = position(l), Tokens.FLOAT
         else
             backup!(l)
@@ -734,6 +753,8 @@ function lex_dot(l::Lexer)
         else
             return emit(l, Tokens.DDOT)
         end
+    elseif Base.isdigit(peekchar(l))
+        return lex_digit(l)
     else
         return emit(l, Tokens.DOT)
     end

--- a/src/lexer.jl
+++ b/src/lexer.jl
@@ -17,7 +17,8 @@ import ..Tokens: FUNCTION, ABSTRACT, IDENTIFIER, BAREMODULE, BEGIN, BITSTYPE, BR
 
 export tokenize
 
-ishex(c::Char) = isdigit(c) || ('a' <= c <= 'f') || ('A' <= c <= 'F') || c == '_'
+isdigit(c::Char) = Base.isdigit(c) || c == '_'
+ishex(c::Char) = isdigit(c) || ('a' <= c <= 'f') || ('A' <= c <= 'F')
 isbinary(c::Char) = c == '0' || c == '1' || c == '_'
 isoctal(c::Char) =  '0' ≤ c ≤ '7' || c == '_'
 iswhitespace(c::Char) = Base.UTF8proc.isspace(c)
@@ -521,17 +522,6 @@ function lex_digit(l::Lexer)
     longest, kind = position(l), Tokens.ERROR
 
     accept_batch(l, isdigit)
-
-    # Accept "_" in digits
-    while true
-        if !accept(l, '_')
-            break
-        end
-        if !accept_batch(l, isdigit)
-            backup!(l)
-            return emit(l, Tokens.INTEGER)
-        end
-    end
 
     if accept(l, '.')
         if peekchar(l) == '.' # 43.. -> [43, ..]

--- a/test/lexer.jl
+++ b/test/lexer.jl
@@ -330,6 +330,15 @@ end
     @test tok("!=b",   1).kind == Tokens.NOT_EQ
 end
 
+@testset "lex integers" begin
+    @test tok("1234").kind            == T.INTEGER
+    @test tok("12_34").kind           == T.INTEGER
+    @test tok("_1234").kind           == T.IDENTIFIER
+    @test tok("1234_").kind           == T.INTEGER
+    @test tok("1234_", 2).kind        == T.IDENTIFIER
+    @test tok("1234x").kind           == T.INTEGER
+    @test tok("1234x", 2).kind        == T.IDENTIFIER
+end
 
 @testset "floats with trailing `.` " begin
     @test tok("1.0").kind == Tokens.FLOAT
@@ -343,6 +352,7 @@ end
     @test tok("1.,").kind == Tokens.FLOAT
     @test tok("1.;").kind == Tokens.FLOAT
     @test tok("1.@").kind == Tokens.FLOAT
+    @test tok("1.").kind == Tokens.FLOAT
     @test tok("1.\"text\" ").kind == Tokens.FLOAT
 
     @test tok("1.+ ").kind == Tokens.INTEGER
@@ -360,6 +370,8 @@ end
     @test tok("1_1.11").kind           == T.FLOAT
     @test tok("11.1_1").kind           == T.FLOAT
     @test tok("1_1.1_1").kind           == T.FLOAT
+    @test tok("_1.1_1", 1).kind           == T.IDENTIFIER
+    @test tok("_1.1_1", 2).kind           == T.FLOAT
     @test tok("0x0167_032").kind           == T.INTEGER
     @test tok("0b0101001_0100_0101").kind  == T.INTEGER
     @test tok("0o01054001_0100_0101").kind == T.INTEGER

--- a/test/lexer.jl
+++ b/test/lexer.jl
@@ -356,7 +356,10 @@ end
     @test tok("0o0167").kind == T.INTEGER
 end
 
-@testset "lex bin/hex/oct w underscores" begin
+@testset "lex float/bin/hex/oct w underscores" begin
+    @test tok("1_1.11").kind           == T.FLOAT
+    @test tok("11.1_1").kind           == T.FLOAT
+    @test tok("1_1.1_1").kind           == T.FLOAT
     @test tok("0x0167_032").kind           == T.INTEGER
     @test tok("0b0101001_0100_0101").kind  == T.INTEGER
     @test tok("0o01054001_0100_0101").kind == T.INTEGER


### PR DESCRIPTION
`"1.02_3" was giving: `[FLOAT, IDENTIFIER]`