### PR TITLE
add invisible generator keywords

### DIFF
--- a/src/token_kinds.jl
+++ b/src/token_kinds.jl
@@ -56,6 +56,8 @@
         COMPREHENSION,
         CURLY,
         DICT_COMPREHENSION,
+        FILTER,
+        FLATTEN,
         GENERATOR,
         HCAT,
         KW,


### PR DESCRIPTION
`flatten` and `filter` used in fancy generators