### PR TITLE
fix FLOAT parsing

### DIFF
--- a/src/lexer.jl
+++ b/src/lexer.jl
@@ -558,6 +558,8 @@ function lex_digit(l::Lexer)
             || peekchar(l) == '@'
             || peekchar(l) == '`'
             || peekchar(l) == '"'
+            || peekchar(l) == ':'
+            || peekchar(l) == '?'
             || eof(l))
             backup!(l)
             return emit(l, Tokens.INTEGER)

--- a/test/lexer.jl
+++ b/test/lexer.jl
@@ -391,6 +391,8 @@ end
     @test tok("201E+0").kind == Tokens.FLOAT
     @test tok("2f+0").kind   == Tokens.FLOAT
     @test tok("2048f0").kind == Tokens.FLOAT
+    @test tok("1.:0").kind == Tokens.FLOAT
+    @test tok("1.?").kind == Tokens.FLOAT
 end
 
 @testset "1e1" begin


### PR DESCRIPTION
No dot operators for `?` or `:` so allow floats w/ trailing dot.