### PR TITLE
Replace all Int64 with Int

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ The API for a `Token` (non exported from the `Tokenize.Tokens` module) is.
 ```julia
 startpos(t)::Tuple{Int, Int} # row and column where the token start
 endpos(t)::Tuple{Int, Int}   # row and column where the token ends
-startbyte(T)::Int64          # byte offset where the token start
-endbyte(t)::Int64            # byte offset where the token ends
+startbyte(T)::Int            # byte offset where the token start
+endbyte(t)::Int              # byte offset where the token ends
 untokenize(t)::String        # string representation of the token
 kind(t)::Token.Kind          # kind of the token
 exactkind(t)::Token.Kind     # exact kind of the token

--- a/src/lexer.jl
+++ b/src/lexer.jl
@@ -29,17 +29,17 @@ type Lexer{IO_t <: IO}
     token_start_row::Int
     token_start_col::Int
 
-    prevpos::Int64
-    token_startpos::Int64
+    prevpos::Int
+    token_startpos::Int
 
     current_row::Int
     current_col::Int
-    current_pos::Int64
+    current_pos::Int
 
     last_token::Tokens.Kind
 end
 
-Lexer(io) = Lexer(io, 1, 1, Int64(-1), Int64(0), 1, 1, Int64(1), Tokens.ERROR)
+Lexer(io) = Lexer(io, 1, 1, -1, 0, 1, 1, 1, Tokens.ERROR)
 Lexer(str::AbstractString) = Lexer(IOBuffer(str))
 
 """

--- a/src/token.jl
+++ b/src/token.jl
@@ -49,14 +49,14 @@ immutable Token
     # Offsets into a string or buffer
     startpos::Tuple{Int, Int} # row, col where token starts /end, col is a string index
     endpos::Tuple{Int, Int}
-    startbyte::Int64 # The byte where the token start in the buffer
-    endbyte::Int64 # The byte where the token ended in the buffer
+    startbyte::Int # The byte where the token start in the buffer
+    endbyte::Int # The byte where the token ended in the buffer
     val::Compat.UTF8String # The actual string of the token
     token_error::TokenError
 end
 
 function Token(kind::Kind, startposition::Tuple{Int, Int}, endposition::Tuple{Int, Int},
-               startbyte::Int64, endbyte::Int64, val::String)
+               startbyte::Int, endbyte::Int, val::String)
     Token(kind, startposition, endposition, startbyte, endbyte, val, NO_ERR)
 end
 Token() = Token(ERROR, (0,0), (0,0), 0, 0, "", UNKNOWN)


### PR DESCRIPTION
This would make things a little simpler because one doesn't have to convert to ``Int64`` on 32 bit julia. And using a 32 bit int on 32 bit machines should be fine, given how these fields are used.