### PR TITLE
Accepted empty char literals in the lexer

### DIFF
--- a/src/lexer.jl
+++ b/src/lexer.jl
@@ -635,7 +635,11 @@ function lex_prime(l)
             if accept(l, '\'')
                 return emit(l, Tokens.CHAR)
             else
-                return emit_error(l, Tokens.EOF_CHAR)
+                # Empty char literal
+                # Arguably this should be an error here, but we generally
+                # look at the contents of the char literal in the parser,
+                # so we defer erroring until there.
+                return emit(l, Tokens.CHAR)
             end
         end
         while true

--- a/test/lexer.jl
+++ b/test/lexer.jl
@@ -224,6 +224,8 @@ end
     @test tokens[16].val==tokens[17].val=="'"
     @test tok("'a'").val == "'a'"
     @test tok("'a'").kind == Tokens.CHAR
+    @test tok("''").val == "''"
+    @test tok("''").kind == Tokens.CHAR
     @test tok("'''").val == "'''"
     @test tok("'''").kind == Tokens.CHAR
     @test tok("''''", 1).kind == Tokens.CHAR


### PR DESCRIPTION
The one thing I know is that EOF_CHAR is the wrong error here, because
it's not actually an EOF (it's a grammar error). However, given that
we don't look at the contents of the char literal at all here (and
basically accept arbitrary string), I think this error should happen
at a higher level, together will all other such errors. As a result,
I propose removing it here.