### PR TITLE
actually test inferability and make RawToken inferrable

### DIFF
--- a/src/token.jl
+++ b/src/token.jl
@@ -54,6 +54,11 @@ struct Token <: AbstractToken
     val::String # The actual string of the token
     token_error::TokenError
 end
+function Token(kind::Kind, startposition::Tuple{Int, Int}, endposition::Tuple{Int, Int},
+    startbyte::Int, endbyte::Int, val::String)
+Token(kind, startposition, endposition, startbyte, endbyte, val, NO_ERR)
+end
+Token() = Token(ERROR, (0,0), (0,0), 0, 0, "", UNKNOWN)
 
 struct RawToken <: AbstractToken
     kind::Kind
@@ -62,15 +67,19 @@ struct RawToken <: AbstractToken
     endpos::Tuple{Int, Int}
     startbyte::Int # The byte where the token start in the buffer
     endbyte::Int # The byte where the token ended in the buffer
+    token_error::TokenError
 end
-
-function Token(kind::Kind, startposition::Tuple{Int, Int}, endposition::Tuple{Int, Int},
-               startbyte::Int, endbyte::Int, val::String)
-    Token(kind, startposition, endposition, startbyte, endbyte, val, NO_ERR)
+function RawToken(kind::Kind, startposition::Tuple{Int, Int}, endposition::Tuple{Int, Int},
+    startbyte::Int, endbyte::Int)
+Token(kind, startposition, endposition, startbyte, endbyte, NO_ERR)
 end
-Token() = Token(ERROR, (0,0), (0,0), 0, 0, "", UNKNOWN)
+RawToken() = RawToken(ERROR, (0,0), (0,0), 0, 0, UNKNOWN)
 
-const EMPTY_TOKEN = Token()
+
+const _EMPTY_TOKEN = Token()
+const _EMPTY_RAWTOKEN = RawToken()
+EMPTY_TOKEN(::Type{Token}) = _EMPTY_TOKEN
+EMPTY_TOKEN(::Type{RawToken}) = _EMPTY_RAWTOKEN
 
 function kind(t::AbstractToken)
     isoperator(t.kind) && return OP

--- a/src/token.jl
+++ b/src/token.jl
@@ -71,7 +71,7 @@ struct RawToken <: AbstractToken
 end
 function RawToken(kind::Kind, startposition::Tuple{Int, Int}, endposition::Tuple{Int, Int},
     startbyte::Int, endbyte::Int)
-Token(kind, startposition, endposition, startbyte, endbyte, NO_ERR)
+RawToken(kind, startposition, endposition, startbyte, endbyte, NO_ERR)
 end
 RawToken() = RawToken(ERROR, (0,0), (0,0), 0, 0, UNKNOWN)
 

--- a/test/lexer.jl
+++ b/test/lexer.jl
@@ -322,9 +322,9 @@ end
 
 @testset "inferred" begin
     l = tokenize("abc")
-    @test Base.Test.@inferred Tokenize.Lexers.next_token(l).kind == T.IDENTIFIER
+    @inferred Tokenize.Lexers.next_token(l)
     l = tokenize("abc", Tokens.RawToken)
-    @test Base.Test.@inferred typeof(Tokenize.Lexers.next_token(l)) == Tokens.RawToken
+    @inferred Tokenize.Lexers.next_token(l)
 end
 
 @testset "modifying function names (!) followed by operator" begin


### PR DESCRIPTION
Our previous test didn't actually test what we thought (it just tested inferability of `==` with `Kind`). Fix the test and fix inferability of RawToken. Also put back the `error` field into `RawToken`.