### PR TITLE
return error on invalid binary/octal/hex intege

### DIFF
--- a/src/lexer.jl
+++ b/src/lexer.jl
@@ -628,6 +628,7 @@ function lex_digit(l::Lexer, kind)
         kind == Tokens.INTEGER
         if pc == 'x'
             readchar(l)
+            !ishex(ppc) && return emit_error(l)
             accept_number(l, ishex)
             if accept(l, '.')
                 accept_number(l, ishex)
@@ -638,9 +639,11 @@ function lex_digit(l::Lexer, kind)
                 accept_number(l, isdigit)
             end
         elseif pc == 'b'
+            !isbiary(ppc) && return emit_error(l)
             readchar(l)
             accept_number(l, isbinary)
         elseif pc == 'o'
+            !isocal(ppc) && return emit_error(l)
             readchar(l)
             accept_number(l, isoctal)
         end

--- a/src/lexer.jl
+++ b/src/lexer.jl
@@ -628,7 +628,7 @@ function lex_digit(l::Lexer, kind)
         kind == Tokens.INTEGER
         if pc == 'x'
             readchar(l)
-            !ishex(ppc) && return emit_error(l)
+            !(ishex(ppc) || ppc =='.') && return emit_error(l)
             accept_number(l, ishex)
             if accept(l, '.')
                 accept_number(l, ishex)

--- a/src/lexer.jl
+++ b/src/lexer.jl
@@ -639,11 +639,11 @@ function lex_digit(l::Lexer, kind)
                 accept_number(l, isdigit)
             end
         elseif pc == 'b'
-            !isbiary(ppc) && return emit_error(l)
+            !isbinary(ppc) && return emit_error(l)
             readchar(l)
             accept_number(l, isbinary)
         elseif pc == 'o'
-            !isocal(ppc) && return emit_error(l)
+            !isoctal(ppc) && return emit_error(l)
             readchar(l)
             accept_number(l, isoctal)
         end

--- a/test/lexer.jl
+++ b/test/lexer.jl
@@ -461,3 +461,11 @@ end
     @test length(collect(tokenize("`\$(#=inline ) comment=#``)`"))) == 3
     @test length(collect(tokenize("`\$(\"inline ) string\"*string(``))`"))) == 3
 end
+
+
+@testset "hex/bin/octal errors" begin
+@test tok("0x").kind == T.ERROR
+@test tok("0b").kind == T.ERROR
+@test tok("0o").kind == T.ERROR
+@test tok("0x 2", 1).kind == T.ERROR
+end

--- a/test/lexer.jl
+++ b/test/lexer.jl
@@ -468,4 +468,5 @@ end
 @test tok("0b").kind == T.ERROR
 @test tok("0o").kind == T.ERROR
 @test tok("0x 2", 1).kind == T.ERROR
+@test tok("0x.1p1").kind == T.FLOAT
 end


### PR DESCRIPTION
so that "0x" returns an error token