### PR TITLE
Fix outdated links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tokenize
 
-[![Build Status](https://travis-ci.org/KristofferC/Tokenize.jl.svg?branch=master)](https://travis-ci.org/KristofferC/Tokenize.jl) [![Build status](https://ci.appveyor.com/api/projects/status/h9d9webkxyhpx790?svg=true)](https://ci.appveyor.com/project/KristofferC/tokenize-jl)  [![codecov.io](https://codecov.io/github/KristofferC/Tokenize.jl/coverage.svg?branch=master)](https://codecov.io/github/KristofferC/Tokenize.jl?branch=master)
+[![Build Status](https://travis-ci.org/JuliaLang/Tokenize.jl.svg?branch=master)](https://travis-ci.org/JuliaLang/Tokenize.jl) [![Build status](https://ci.appveyor.com/api/projects/status/h9d9webkxyhpx790?svg=true)](https://ci.appveyor.com/project/KristofferC/tokenize-jl)  [![codecov.io](https://codecov.io/github/JuliaLang/Tokenize.jl/coverage.svg?branch=master)](https://codecov.io/github/JuliaLang/Tokenize.jl?branch=master)
 
 
 `Tokenize` is a Julia package that serves a similar purpose and API as the [tokenize module](https://docs.python.org/3/library/tokenize.html) in Python but for Julia. This is to take a string or buffer containing Julia code, perform lexical analysis and return a stream of tokens.
@@ -59,4 +59,4 @@ julia> Tokens.exactkind(tok)
 RIGHTWARDS_DOUBLE_ARROW::Tokenize.Tokens.Kind = 128
 ```
 
-All the different `Token.Kind` can be seen in the [`token_kinds.jl` file](https://github.com/KristofferC/Tokenize.jl/blob/master/src/token_kinds.jl)
+All the different `Token.Kind` can be seen in the [`token_kinds.jl` file](https://github.com/JuliaLang/Tokenize.jl/blob/master/src/token_kinds.jl)


### PR DESCRIPTION
The links and corresponding buttons were outdated (admit it, you just didn't want to see your code coverage decrease for once!). I also changed the link to the `token_kinds.jl` file so it's consistent and resolves more quickly.

I did not know what to do with the AppVeyor links though as the site does not work for me and the button link is cryptic.