### PR TITLE
mark suffixed ops (needed for CSTParser)

### DIFF
--- a/src/lexer.jl
+++ b/src/lexer.jl
@@ -244,6 +244,7 @@ end
 Returns a `Token` of kind `kind` with contents `str` and starts a new `Token`.
 """
 function emit(l::Lexer{IO_t,Token}, kind::Kind, err::TokenError = Tokens.NO_ERR) where IO_t
+    suffix = false
     if (kind == Tokens.IDENTIFIER || isliteral(kind) || kind == Tokens.COMMENT || kind == Tokens.WHITESPACE)
         str = String(take!(l.charstore))
     elseif kind == Tokens.ERROR
@@ -252,6 +253,7 @@ function emit(l::Lexer{IO_t,Token}, kind::Kind, err::TokenError = Tokens.NO_ERR)
         str = ""
         while isopsuffix(peekchar(l))
             str = string(str, readchar(l))
+            suffix = true
         end
     else
         str = ""
@@ -259,7 +261,7 @@ function emit(l::Lexer{IO_t,Token}, kind::Kind, err::TokenError = Tokens.NO_ERR)
     tok = Token(kind, (l.token_start_row, l.token_start_col),
             (l.current_row, l.current_col - 1),
             startpos(l), position(l) - 1,
-            str, err, l.dotop)
+            str, err, l.dotop, suffix)
     l.dotop = false
     l.last_token = kind
     readoff(l)
@@ -267,15 +269,17 @@ function emit(l::Lexer{IO_t,Token}, kind::Kind, err::TokenError = Tokens.NO_ERR)
 end
 
 function emit(l::Lexer{IO_t,RawToken}, kind::Kind, err::TokenError = Tokens.NO_ERR) where IO_t
+    suffix = false
     if optakessuffix(kind)
         while isopsuffix(peekchar(l))
             readchar(l)
+            suffix = true
         end
     end
 
     tok = RawToken(kind, (l.token_start_row, l.token_start_col),
                   (l.current_row, l.current_col - 1),
-                  startpos(l), position(l) - 1, err, l.dotop)
+                  startpos(l), position(l) - 1, err, l.dotop, suffix)
     
     l.dotop = false
     l.last_token = kind

--- a/src/token.jl
+++ b/src/token.jl
@@ -58,12 +58,13 @@ struct Token <: AbstractToken
     val::String # The actual string of the token
     token_error::TokenError
     dotop::Bool
+    suffix::Bool
 end
 function Token(kind::Kind, startposition::Tuple{Int, Int}, endposition::Tuple{Int, Int},
     startbyte::Int, endbyte::Int, val::String)
-Token(kind, startposition, endposition, startbyte, endbyte, val, NO_ERR, false)
+Token(kind, startposition, endposition, startbyte, endbyte, val, NO_ERR, false, false)
 end
-Token() = Token(ERROR, (0,0), (0,0), 0, 0, "", UNKNOWN, false)
+Token() = Token(ERROR, (0,0), (0,0), 0, 0, "", UNKNOWN, false, false)
 
 struct RawToken <: AbstractToken
     kind::Kind
@@ -74,12 +75,13 @@ struct RawToken <: AbstractToken
     endbyte::Int # The byte where the token ended in the buffer
     token_error::TokenError
     dotop::Bool
+    suffix::Bool
 end
 function RawToken(kind::Kind, startposition::Tuple{Int, Int}, endposition::Tuple{Int, Int},
     startbyte::Int, endbyte::Int)
-RawToken(kind, startposition, endposition, startbyte, endbyte, NO_ERR, false)
+RawToken(kind, startposition, endposition, startbyte, endbyte, NO_ERR, false, false)
 end
-RawToken() = RawToken(ERROR, (0,0), (0,0), 0, 0, UNKNOWN, false)
+RawToken() = RawToken(ERROR, (0,0), (0,0), 0, 0, UNKNOWN, false, false)
 
 
 const _EMPTY_TOKEN = Token()
@@ -133,7 +135,7 @@ function untokenize(t::Token)
 end
 
 function untokenize(t::RawToken, str::String)
-    String(str[1 + (t.startbyte:t.endbyte)])
+    String(codeunits(str)[1 .+ (t.startbyte:t.endbyte)])
 end
 
 function untokenize(ts)

--- a/test/lexer.jl
+++ b/test/lexer.jl
@@ -543,4 +543,12 @@ end
 
 @testset "hat suffix" begin 
     @test tok("ŝ", 1).kind==Tokens.IDENTIFIER
+    @test untokenize(collect(tokenize("ŝ", Tokens.RawToken))[1], "ŝ") == "ŝ"
 end
+
+@testset "suffixed op" begin 
+    s = "+¹"
+    @test Tokens.isoperator(tok(s, 1).kind)
+    @test untokenize(collect(tokenize(s, Tokens.RawToken))[1], s) == s
+end
+


### PR DESCRIPTION
Fix to allow for conversion in CSTParser of suffixed operators when using `RawTokens`. @KristofferC could you merge and tag a minor release?