### PR TITLE
Evaluated token

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ untokenize(t)::String        # string representation of the token
 kind(t)::Token.Kind          # kind of the token
 exactkind(t)::Token.Kind     # exact kind of the token
 teval(t)                     # Parses and evaluates a Token.
+ttypeof(t)                   # Returns the type of an evaluated Token
 ```
 
 The difference between `kind` and `exactkind` is that `kind` returns `OP` for all operators and `KEYWORD` for all keywords while `exactkind` returns a unique kind for all different operators and keywords, ex;

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ endbyte(t)::Int              # byte offset where the token ends
 untokenize(t)::String        # string representation of the token
 kind(t)::Token.Kind          # kind of the token
 exactkind(t)::Token.Kind     # exact kind of the token
-teval(t)                     # Parses and evaluates a Token.
+tevalfast(t)                 # Parses and evaluates a Token. Uses `tgetfield(t)`, `teval(t)`, `evalfast(t)`
+tisdefined(t)                # Check if a `Token` that represent a `Symbol` is defined.
 ttypeof(t)                   # Returns the type of an evaluated Token
 tisa(t)                      # Compares the specified type with the type of an evaluated Token
 ```

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ endbyte(t)::Int              # byte offset where the token ends
 untokenize(t)::String        # string representation of the token
 kind(t)::Token.Kind          # kind of the token
 exactkind(t)::Token.Kind     # exact kind of the token
+teval(t)                     # Parses and evaluates a Token.
 ```
 
 The difference between `kind` and `exactkind` is that `kind` returns `OP` for all operators and `KEYWORD` for all keywords while `exactkind` returns a unique kind for all different operators and keywords, ex;

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ kind(t)::Token.Kind          # kind of the token
 exactkind(t)::Token.Kind     # exact kind of the token
 teval(t)                     # Parses and evaluates a Token.
 ttypeof(t)                   # Returns the type of an evaluated Token
+tisa(t)                      # Compares the specified type with the type of an evaluated Token
 ```
 
 The difference between `kind` and `exactkind` is that `kind` returns `OP` for all operators and `KEYWORD` for all keywords while `exactkind` returns a unique kind for all different operators and keywords, ex;

--- a/src/_precompile.jl
+++ b/src/_precompile.jl
@@ -104,5 +104,5 @@ function _precompile_()
     precompile(Tokenize.Lexers.accept, (Tokenize.Lexers.Lexer{GenericIOBuffer{Array{UInt8, 1}},Tokenize.Tokens.RawToken}, Function,))
 
 
-    precompile(Tokenize.Lexers.readchar, (GenericIOBuffer{Array{UInt8, 1}},))    
+    precompile(Tokenize.Lexers.readchar, (GenericIOBuffer{Array{UInt8, 1}},))
 end

--- a/src/lexer.jl
+++ b/src/lexer.jl
@@ -53,7 +53,7 @@ function Lexer(io::IO_t, T::Type{TT} = Token) where {IO_t,TT <: AbstractToken}
             c3 = read(io, Char)
             p3 = position(io)
         end
-        
+
     end
     Lexer{IO_t,T}(io, position(io), 1, 1, position(io), 1, 1, position(io), Tokens.ERROR, IOBuffer(), (c1,c2,c3), (p1,p2,p3), false, false)
 end
@@ -280,7 +280,7 @@ function emit(l::Lexer{IO_t,RawToken}, kind::Kind, err::TokenError = Tokens.NO_E
     tok = RawToken(kind, (l.token_start_row, l.token_start_col),
                   (l.current_row, l.current_col - 1),
                   startpos(l), position(l) - 1, err, l.dotop, suffix)
-    
+
     l.dotop = false
     l.last_token = kind
     readoff(l)
@@ -942,7 +942,7 @@ end
 
 # A ` has been consumed
 function lex_cmd(l::Lexer, doemit=true)
-    if accept(l, '`') # 
+    if accept(l, '`') #
         if accept(l, '`') # """
             if read_string(l, Tokens.TRIPLE_CMD)
                 return doemit ? emit(l, Tokens.TRIPLE_CMD) : EMPTY_TOKEN(token_type(l))
@@ -952,7 +952,7 @@ function lex_cmd(l::Lexer, doemit=true)
         else # empty cmd
             return doemit ? emit(l, Tokens.CMD) : EMPTY_TOKEN(token_type(l))
         end
-    else 
+    else
         if read_string(l, Tokens.CMD)
             return doemit ? emit(l, Tokens.CMD) : EMPTY_TOKEN(token_type(l))
         else

--- a/src/token.jl
+++ b/src/token.jl
@@ -101,12 +101,12 @@ Meta.parse(t::T) where {T <: Union{Token, Array{Token}}} = Meta.parse(untokenize
 
 """
     tevalfast(t::T)
-    tevalfast(t::T, checkIsdefined::Bool=false)
-    tevalfast(Module = @__MODULE__, t::T, checkIsdefined::Bool=false)
+    tevalfast(t::T, check_isdefined::Bool=false)
+    tevalfast(modul = @__MODULE__, t::T, check_isdefined::Bool=false)
 
-Parses and evaluates a Token that represents a `Symbol` or `Expr` in Julia. For `Symbol` It dispatches on the fast method based on the parsed Token.
+Parses and evaluates a `Token` that represents a `Symbol` or `Expr` in Julia. For `Symbol` It dispatches on the fast method based on the parsed Token.
 
-If you set checkIsdefined to true, and t is not defined in the scope it returns undef instead of throwing an error.
+If you set `check_isdefined` to `true`, and `t` is not defined in the scope it returns `nothing` instead of throwing an error.
 
 # Examples
 ```julia
@@ -116,19 +116,19 @@ julia> tevalfast(t)
 Int64
 ```
 """
-function tevalfast(Module, t::T, checkIsdefined::Bool = false) where {T <: Union{Token, Array{Token}}}
+function tevalfast(modul, t::T, check_isdefined::Bool = false) where {T <: Union{Token, Array{Token}}}
     pt = Meta.parse(t)
-    if checkIsdefined && !(isdefined(Module,pt))
-        return undef
+    if check_isdefined && !(isdefined(modul,pt))
+        return nothing
     end
-    return evalfast(Module,pt)
+    return evalfast(modul,pt)
 end
 
 """
     evalfast(x)
-    evalfast(Module, x)
+    evalfast(modul, x)
 
-Evaluates x fast. Uses `getfield` if x is an Symbol, and uses `eval` if it is an `Expr`
+Evaluates `x` fast. Uses `getfield` if `x` is a `Symbol`, and uses `eval` if it is an `Expr`
 # Examples
 ```julia
 julia> evalfast(:Int64)
@@ -137,21 +137,21 @@ julia> evalfast(:([5]))
 
 ```
 """
-evalfast(Module, x::Expr)= Module.eval(x)
-evalfast(Module, x::Symbol)= getfield(Module,x)
+evalfast(modul, x::Expr)= modul.eval(x)
+evalfast(modul, x::Symbol)= getfield(modul,x)
 evalfast(x::Expr)= Core.eval(@__MODULE__, x)
 evalfast(x::Symbol)= getfield(@__MODULE__,x)
 
 """
     tgetfield(t::T)
-    tgetfield(t::T, checkIsdefined::Bool=false)
-    tgetfield(Module = @__MODULE__, t::T, checkIsdefined::Bool=false)
+    tgetfield(t::T, check_isdefined::Bool=false)
+    tgetfield(modul = @__MODULE__, t::T, check_isdefined::Bool=false)
 
 See [`tevalfast`](@ref) for fast Token evaluation.
 
 Parses and evaluates a Token that represents a `Symbol` in Julia. For `Symbol` it is similar to eval, but much faster.
 
-If you set checkIsdefined to true, and t is not defined in the scope it returns undef instead of throwing an error.
+If you set `check_isdefined` to `true`, and `t` is not defined in the scope it returns `nothing` instead of throwing an error.
 
 # Examples
 ```julia
@@ -161,26 +161,26 @@ julia> tgetfield(t)
 Int64
 ```
 """
-function tgetfield(Module, t::T, checkIsdefined::Bool = false) where {T <: Union{Token, Array{Token}}}
+function tgetfield(modul, t::T, check_isdefined::Bool = false) where {T <: Union{Token, Array{Token}}}
     pt = Meta.parse(t)
-    if checkIsdefined && !(isdefined(Module,pt))
-        return undef
+    if check_isdefined && !(isdefined(modul,pt))
+        return nothing
     end
-    return getfield(Module,pt)
+    return getfield(modul,pt)
 end
 
-tgetfield(t::T, checkIsdefined::Bool = false) where {T <: Union{Token, Array{Token}}} = tgetfield(@__MODULE__, t, checkIsdefined)
+tgetfield(t::T, check_isdefined::Bool = false) where {T <: Union{Token, Array{Token}}} = tgetfield(@__MODULE__, t, check_isdefined)
 
 """
-    teval(t::T, checkIsdefined::Bool=false)
-    teval(t::T, checkIsdefined::Bool=false)
-    teval(Module = @__MODULE__, t::T, checkIsdefined::Bool=false)
+    teval(t::T, check_isdefined::Bool=false)
+    teval(t::T, check_isdefined::Bool=false)
+    teval(modul = @__MODULE__, t::T, check_isdefined::Bool=false)
 
 See [`tevalfast`](@ref) for fast Token evaluation.
 
-Parses and evaluates a Token.
+Parses and evaluates a `Token`.
 
-If you set checkIsdefined to true, and t is not defined in the scope it returns undef instead of throwing an error.
+If you set `check_isdefined` to `true`, and `t` is not defined in the scope it returns `nothing` instead of throwing an error.
 
 # Examples
 ```julia
@@ -190,22 +190,22 @@ julia> teval(t)
 Int64
 ```
 """
-function teval(Module, t::T, checkIsdefined::Bool = false) where {T <: Union{Token, Array{Token}}}
+function teval(modul, t::T, check_isdefined::Bool = false) where {T <: Union{Token, Array{Token}}}
     pt = Meta.parse(t)
-    if checkIsdefined && !(isdefined(Module,pt))
-        return undef
+    if check_isdefined && !(isdefined(modul,pt))
+        return nothing
     end
-    return Core.eval(Module, pt)
+    return Core.eval(modul, pt)
 end
-teval(t::T, checkIsdefined::Bool = false) where {T <: Union{Token, Array{Token}}} = teval(@__MODULE__, t, checkIsdefined)
+teval(t::T, check_isdefined::Bool = false) where {T <: Union{Token, Array{Token}}} = teval(@__MODULE__, t, check_isdefined)
 
 """
     ttypeof(t)
-    ttypeof(t::T, checkIsdefined::Bool = false)
+    ttypeof(t::T, check_isdefined::Bool = false)
 
 Returns the type of an evaluated Token
 
-If you set checkIsdefined to true, and t is not defined in the scope it returns undef.
+If you set `check_isdefined` to `true`, and `t` is not defined in the scope it returns `nothing` instead of throwing an error.
 
 # Examples
 ```julia
@@ -215,15 +215,15 @@ julia> ttypeof(t)
 DataType
 ```
 """
-ttypeof(t::T, checkIsdefined::Bool = false) where {T <: Union{Token, Array{Token}}} = typeof(tevalfast(t, checkIsdefined))
+ttypeof(t::T, check_isdefined::Bool = false) where {T <: Union{Token, Array{Token}}} = typeof(tevalfast(t, check_isdefined))
 
 """
     tisa(t, T::Type)
-    tisa(t::T, Tspecified::Type, checkIsdefined::Bool = false)
+    tisa(t::T, Tspecified::Type, check_isdefined::Bool = false)
 
 Compares the specified type with the type of an evaluated Token
 
-If you set checkIsdefined to true, and t is not defined in the scope it returns undef.
+If you set `check_isdefined` to `true`, and `t` is not defined in the scope it returns `nothing` instead of throwing an error.
 
 # Examples
 ```julia
@@ -233,7 +233,7 @@ julia> tisa(t, DataType)
 true
 ```
 """
-tisa(t::T, Tspecified::Type, checkIsdefined::Bool = false) where {T <: Union{Token, Array{Token}}} = isa(tevalfast(t, checkIsdefined), Tspecified)
+tisa(t::T, Tspecified::Type, check_isdefined::Bool = false) where {T <: Union{Token, Array{Token}}} = isa(tevalfast(t, check_isdefined), Tspecified)
 
 startpos(t::AbstractToken) = t.startpos
 endpos(t::AbstractToken) = t.endpos

--- a/src/token.jl
+++ b/src/token.jl
@@ -95,7 +95,23 @@ function kind(t::AbstractToken)
     return t.kind
 end
 exactkind(t::AbstractToken) = t.kind
+
 Meta.parse(t::Token) = Meta.parse(untokenize(t))
+
+"""
+    teval(t)
+
+Parses and evaluates a Token.
+# Examples
+```julia
+julia> t = collect(tokenize("Int64"))
+
+julia> teval(t)
+Int64
+```
+"""
+teval(t::Token) = eval(Meta.parse(t))
+
 startpos(t::AbstractToken) = t.startpos
 endpos(t::AbstractToken) = t.endpos
 startbyte(t::AbstractToken) = t.startbyte

--- a/src/token.jl
+++ b/src/token.jl
@@ -96,7 +96,7 @@ function kind(t::AbstractToken)
 end
 exactkind(t::AbstractToken) = t.kind
 
-Meta.parse(t::Token) = Meta.parse(untokenize(t))
+Meta.parse(t::T) where {T <: Union{Token, Array{Token}}} = Meta.parse(untokenize(t))
 
 """
     teval(t)
@@ -110,7 +110,7 @@ julia> teval(t)
 Int64
 ```
 """
-teval(t::Token) = eval(Meta.parse(t))
+teval(t::T) where {T <: Union{Token, Array{Token}}} = eval(Meta.parse(t))
 
 """
     ttypeof(t)
@@ -125,7 +125,7 @@ julia> ttypeof(t)
 DataType
 ```
 """
-ttypeof(t::Token) = typeof(teval(t))
+ttypeof(t::T) where {T <: Union{Token, Array{Token}}} = typeof(teval(t))
 
 """
     tisa(t, T::Type)
@@ -140,7 +140,7 @@ julia> tisa(t, DataType)
 true
 ```
 """
-tisa(t::Token, T::Type) = isa(teval(t), T)
+tisa(t::T, Tspecified::Type) where {T <: Union{Token, Array{Token}}} = isa(teval(t), Tspecified)
 
 startpos(t::AbstractToken) = t.startpos
 endpos(t::AbstractToken) = t.endpos

--- a/src/token.jl
+++ b/src/token.jl
@@ -95,6 +95,7 @@ function kind(t::AbstractToken)
     return t.kind
 end
 exactkind(t::AbstractToken) = t.kind
+Meta.parse(t::Token) = Meta.parse(untokenize(t))
 startpos(t::AbstractToken) = t.startpos
 endpos(t::AbstractToken) = t.endpos
 startbyte(t::AbstractToken) = t.startbyte

--- a/src/token.jl
+++ b/src/token.jl
@@ -147,7 +147,7 @@ julia> tevalfast(t)
 Int64
 ```
 """
-function tevalfast(modul, t::T, check_isdefined::Bool = false) where {T <: Union{Token, Array{Token}}}
+function tevalfast(modul::Module, t::T, check_isdefined::Bool = false) where {T <: Union{Token, Array{Token}}}
     pt = Meta.parse(t)
     if check_isdefined && !(tisdefined(modul,pt))
         return UndefToken
@@ -170,8 +170,8 @@ julia> evalfast(:([5]))
 
 ```
 """
-evalfast(modul, x::Expr)= modul.eval(x)
-evalfast(modul, x::Symbol)= getfield(modul,x)
+evalfast(modul::Module, x::Expr)= modul.eval(x)
+evalfast(modul::Module, x::Symbol)= getfield(modul,x)
 evalfast(x::Expr)= Core.eval(@__MODULE__, x)
 evalfast(x::Symbol)= getfield(@__MODULE__,x)
 
@@ -194,7 +194,7 @@ julia> tgetfield(t)
 Int64
 ```
 """
-function tgetfield(modul, t::T, check_isdefined::Bool = false) where {T <: Union{Token, Array{Token}}}
+function tgetfield(modul::Module, t::T, check_isdefined::Bool = false) where {T <: Union{Token, Array{Token}}}
     pt = Meta.parse(t)
     if check_isdefined && !(tisdefined(modul,pt))
         return UndefToken
@@ -223,7 +223,7 @@ julia> teval(t)
 Int64
 ```
 """
-function teval(modul, t::T, check_isdefined::Bool = false) where {T <: Union{Token, Array{Token}}}
+function teval(modul::Module, t::T, check_isdefined::Bool = false) where {T <: Union{Token, Array{Token}}}
     pt = Meta.parse(t)
     if check_isdefined && !(tisdefined(modul,pt))
         return UndefToken

--- a/src/token.jl
+++ b/src/token.jl
@@ -126,6 +126,22 @@ DataType
 ```
 """
 ttypeof(t::Token) = typeof(teval(t))
+
+"""
+    tisa(t, T::Type)
+
+Compares the specified type with the type of an evaluated Token
+
+# Examples
+```julia
+julia> t = collect(tokenize("Int64"))
+
+julia> tisa(t, DataType)
+true
+```
+"""
+tisa(t::Token, T::Type) = isa(teval(t), T)
+
 startpos(t::AbstractToken) = t.startpos
 endpos(t::AbstractToken) = t.endpos
 startbyte(t::AbstractToken) = t.startbyte

--- a/src/token.jl
+++ b/src/token.jl
@@ -98,6 +98,30 @@ exactkind(t::AbstractToken) = t.kind
 
 Meta.parse(t::T) where {T <: Union{Token, Array{Token}}} = Meta.parse(untokenize(t))
 
+"""
+    tisdefined(t)
+    tisdefined(modul, t)
+
+Check if a `Token` that represent a `Symbol` is defined. Throws error if the `Token` is representing an `Expr`.
+
+# Examples
+```julia
+julia> t = collect(tokenize("Int64"))
+
+julia> tisdefined(t)
+true
+```
+"""
+function tisdefined(modul, t::T) where {T <: Union{Token, Array{Token}}}
+    pt = Meta.parse(t)
+    return isdefined(modul,pt)
+end
+
+tisdefined(t::T) where {T <: Union{Token, Array{Token}}} = tisdefined(@__MODULE__, t)
+
+tisdefined(modul, t::T) where {T <: Union{Symbol, Expr}} = isdefined(modul, t)
+tisdefined(t::T) where {T <: Union{Symbol, Expr}} = isdefined(@__MODULE__, t)
+
 
 """
     tevalfast(t::T)

--- a/src/token.jl
+++ b/src/token.jl
@@ -124,6 +124,8 @@ function tevalfast(modul, t::T, check_isdefined::Bool = false) where {T <: Union
     return evalfast(modul,pt)
 end
 
+tevalfast(t::T, check_isdefined::Bool = false) where {T <: Union{Token, Array{Token}}} = tevalfast(@__MODULE__, t, check_isdefined)
+
 """
     evalfast(x)
     evalfast(modul, x)

--- a/src/token.jl
+++ b/src/token.jl
@@ -99,6 +99,13 @@ exactkind(t::AbstractToken) = t.kind
 Meta.parse(t::T) where {T <: Union{Token, Array{Token}}} = Meta.parse(untokenize(t))
 
 """
+    UndefToken
+
+An abstract type that shows if the an evaluated `Token` is defined.
+"""
+abstract type UndefToken end
+
+"""
     tisdefined(t)
     tisdefined(modul, t)
 
@@ -130,7 +137,7 @@ tisdefined(t::T) where {T <: Union{Symbol, Expr}} = isdefined(@__MODULE__, t)
 
 Parses and evaluates a `Token` that represents a `Symbol` or `Expr` in Julia. For `Symbol` It dispatches on the fast method based on the parsed Token.
 
-If you set `check_isdefined` to `true`, and `t` is not defined in the scope it returns `nothing` instead of throwing an error.
+If you set `check_isdefined` to `true`, and `t` is not defined in the scope it returns `UndefToken` instead of throwing an error.
 
 # Examples
 ```julia
@@ -142,8 +149,8 @@ Int64
 """
 function tevalfast(modul, t::T, check_isdefined::Bool = false) where {T <: Union{Token, Array{Token}}}
     pt = Meta.parse(t)
-    if check_isdefined && !(isdefined(modul,pt))
-        return nothing
+    if check_isdefined && !(tisdefined(modul,pt))
+        return UndefToken
     end
     return evalfast(modul,pt)
 end
@@ -177,7 +184,7 @@ See [`tevalfast`](@ref) for fast Token evaluation.
 
 Parses and evaluates a Token that represents a `Symbol` in Julia. For `Symbol` it is similar to eval, but much faster.
 
-If you set `check_isdefined` to `true`, and `t` is not defined in the scope it returns `nothing` instead of throwing an error.
+If you set `check_isdefined` to `true`, and `t` is not defined in the scope it returns `UndefToken` instead of throwing an error.
 
 # Examples
 ```julia
@@ -189,8 +196,8 @@ Int64
 """
 function tgetfield(modul, t::T, check_isdefined::Bool = false) where {T <: Union{Token, Array{Token}}}
     pt = Meta.parse(t)
-    if check_isdefined && !(isdefined(modul,pt))
-        return nothing
+    if check_isdefined && !(tisdefined(modul,pt))
+        return UndefToken
     end
     return getfield(modul,pt)
 end
@@ -206,7 +213,7 @@ See [`tevalfast`](@ref) for fast Token evaluation.
 
 Parses and evaluates a `Token`.
 
-If you set `check_isdefined` to `true`, and `t` is not defined in the scope it returns `nothing` instead of throwing an error.
+If you set `check_isdefined` to `true`, and `t` is not defined in the scope it returns `UndefToken` instead of throwing an error.
 
 # Examples
 ```julia
@@ -218,8 +225,8 @@ Int64
 """
 function teval(modul, t::T, check_isdefined::Bool = false) where {T <: Union{Token, Array{Token}}}
     pt = Meta.parse(t)
-    if check_isdefined && !(isdefined(modul,pt))
-        return nothing
+    if check_isdefined && !(tisdefined(modul,pt))
+        return UndefToken
     end
     return Core.eval(modul, pt)
 end
@@ -231,7 +238,7 @@ teval(t::T, check_isdefined::Bool = false) where {T <: Union{Token, Array{Token}
 
 Returns the type of an evaluated Token
 
-If you set `check_isdefined` to `true`, and `t` is not defined in the scope it returns `nothing` instead of throwing an error.
+If you set `check_isdefined` to `true`, and `t` is not defined in the scope it returns `UndefToken` instead of throwing an error.
 
 # Examples
 ```julia
@@ -249,7 +256,7 @@ ttypeof(t::T, check_isdefined::Bool = false) where {T <: Union{Token, Array{Toke
 
 Compares the specified type with the type of an evaluated Token
 
-If you set `check_isdefined` to `true`, and `t` is not defined in the scope it returns `nothing` instead of throwing an error.
+If you set `check_isdefined` to `true`, and `t` is not defined in the scope it returns `UndefToken` instead of throwing an error.
 
 # Examples
 ```julia

--- a/src/token.jl
+++ b/src/token.jl
@@ -198,11 +198,11 @@ function untokenize(t::Token)
         return lowercase(string(t.kind))
     elseif isoperator(t.kind)
         if t.dotop
-            str = string(".", UNICODE_OPS_REVERSE[t.kind]) 
-        else 
-            str = string(UNICODE_OPS_REVERSE[t.kind]) 
-        end 
-        return string(str, t.val) 
+            str = string(".", UNICODE_OPS_REVERSE[t.kind])
+        else
+            str = string(UNICODE_OPS_REVERSE[t.kind])
+        end
+        return string(str, t.val)
     elseif t.kind == LPAREN
         return "("
     elseif t.kind == LSQUARE

--- a/src/token.jl
+++ b/src/token.jl
@@ -99,8 +99,6 @@ exactkind(t::AbstractToken) = t.kind
 Meta.parse(t::T) where {T <: Union{Token, Array{Token}}} = Meta.parse(untokenize(t))
 
 """
-    teval(t)
-    teval(t, checkIsdefined::Bool=false)
     tgetfield(t::T)
     tgetfield(t::T, checkIsdefined::Bool=false)
     tgetfield(Module = @__MODULE__, t::T, checkIsdefined::Bool=false)
@@ -127,9 +125,14 @@ end
 
 tgetfield(t::T, checkIsdefined::Bool = false) where {T <: Union{Token, Array{Token}}} = tgetfield(@__MODULE__, t, checkIsdefined)
 
+"""
+    teval(t::T, checkIsdefined::Bool=false)
+    teval(t::T, checkIsdefined::Bool=false)
+    teval(Module = @__MODULE__, t::T, checkIsdefined::Bool=false)
+
 Parses and evaluates a Token.
 
-If you set checkIsdefined to true, and t is not defined in the scope, it returns undef.
+If you set checkIsdefined to true, and t is not defined in the scope it returns undef instead of throwing an error.
 
 # Examples
 ```julia
@@ -139,20 +142,22 @@ julia> teval(t)
 Int64
 ```
 """
-function teval(t::T, checkIsdefined::Bool = false) where {T <: Union{Token, Array{Token}}}
+function teval(Module, t::T, checkIsdefined::Bool = false) where {T <: Union{Token, Array{Token}}}
     pt = Meta.parse(t)
-    if checkIsdefined && !(isdefined(@__MODULE__,pt))
+    if checkIsdefined && !(isdefined(Module,pt))
         return undef
     end
-    return eval(pt)
+    return Module.eval(pt)
 end
+teval(t::T, checkIsdefined::Bool = false) where {T <: Union{Token, Array{Token}}} = teval(@__MODULE__, t, checkIsdefined)
+
 """
     ttypeof(t)
-    ttypeof(t, checkIsdefined::Bool = false)
+    ttypeof(t::T, checkIsdefined::Bool = false)
 
 Returns the type of an evaluated Token
 
-If you set checkIsdefined to true, and t is not defined in the scope, it returns undef.
+If you set checkIsdefined to true, and t is not defined in the scope it returns undef.
 
 # Examples
 ```julia
@@ -162,15 +167,15 @@ julia> ttypeof(t)
 DataType
 ```
 """
-ttypeof(t::T, checkIsdefined::Bool = false) where {T <: Union{Token, Array{Token}}} = typeof(teval(t, checkIsdefined))
+ttypeof(t::T, checkIsdefined::Bool = false) where {T <: Union{Token, Array{Token}}} = typeof(tgetfield(t, checkIsdefined))
 
 """
     tisa(t, T::Type)
-    tisa(t, Tspecified::Type, checkIsdefined::Bool = false)
+    tisa(t::T, Tspecified::Type, checkIsdefined::Bool = false)
 
 Compares the specified type with the type of an evaluated Token
 
-If you set checkIsdefined to true, and t is not defined in the scope, it returns undef.
+If you set checkIsdefined to true, and t is not defined in the scope it returns undef.
 
 # Examples
 ```julia
@@ -180,7 +185,7 @@ julia> tisa(t, DataType)
 true
 ```
 """
-tisa(t::T, Tspecified::Type, checkIsdefined::Bool = false) where {T <: Union{Token, Array{Token}}} = isa(teval(t, checkIsdefined), Tspecified)
+tisa(t::T, Tspecified::Type, checkIsdefined::Bool = false) where {T <: Union{Token, Array{Token}}} = isa(tgetfield(t, checkIsdefined), Tspecified)
 
 startpos(t::AbstractToken) = t.startpos
 endpos(t::AbstractToken) = t.endpos

--- a/src/token.jl
+++ b/src/token.jl
@@ -112,6 +112,20 @@ Int64
 """
 teval(t::Token) = eval(Meta.parse(t))
 
+"""
+    ttypeof(t)
+
+Returns the type of an evaluated Token
+
+# Examples
+```julia
+julia> t = collect(tokenize("Int64"))
+
+julia> ttypeof(t)
+DataType
+```
+"""
+ttypeof(t::Token) = typeof(teval(t))
 startpos(t::AbstractToken) = t.startpos
 endpos(t::AbstractToken) = t.endpos
 startbyte(t::AbstractToken) = t.startbyte

--- a/src/token.jl
+++ b/src/token.jl
@@ -99,6 +99,24 @@ exactkind(t::AbstractToken) = t.kind
 Meta.parse(t::T) where {T <: Union{Token, Array{Token}}} = Meta.parse(untokenize(t))
 
 """
+    evalfast(x)
+    evalfast(Module, x)
+
+Evaluates x fast. Uses `getfield` if x is an Symbol, and uses `eval` if it is an `Expr`
+# Examples
+```julia
+julia> evalfast(:Int64)
+
+julia> evalfast(:([5]))
+
+```
+"""
+evalfast(Module, x::Expr)= Module.eval(x)
+evalfast(Module, x::Symbol)= getfield(Module,x)
+evalfast(x::Expr)= Core.eval(@__MODULE__, x)
+evalfast(x::Symbol)= getfield(@__MODULE__,x)
+
+"""
     tgetfield(t::T)
     tgetfield(t::T, checkIsdefined::Bool=false)
     tgetfield(Module = @__MODULE__, t::T, checkIsdefined::Bool=false)

--- a/src/token.jl
+++ b/src/token.jl
@@ -100,8 +100,12 @@ Meta.parse(t::T) where {T <: Union{Token, Array{Token}}} = Meta.parse(untokenize
 
 """
     teval(t)
+    teval(t, checkIsdefined::Bool=false)
 
 Parses and evaluates a Token.
+
+If you set checkIsdefined to true, and t is not defined in the scope, it returns undef.
+
 # Examples
 ```julia
 julia> t = collect(tokenize("Int64"))
@@ -110,12 +114,20 @@ julia> teval(t)
 Int64
 ```
 """
-teval(t::T) where {T <: Union{Token, Array{Token}}} = eval(Meta.parse(t))
-
+function teval(t::T, checkIsdefined::Bool = false) where {T <: Union{Token, Array{Token}}}
+    pt = Meta.parse(t)
+    if checkIsdefined && !(isdefined(@__MODULE__,pt))
+        return undef
+    end
+    return eval(pt)
+end
 """
     ttypeof(t)
+    ttypeof(t, checkIsdefined::Bool = false)
 
 Returns the type of an evaluated Token
+
+If you set checkIsdefined to true, and t is not defined in the scope, it returns undef.
 
 # Examples
 ```julia
@@ -125,12 +137,15 @@ julia> ttypeof(t)
 DataType
 ```
 """
-ttypeof(t::T) where {T <: Union{Token, Array{Token}}} = typeof(teval(t))
+ttypeof(t::T, checkIsdefined::Bool = false) where {T <: Union{Token, Array{Token}}} = typeof(teval(t, checkIsdefined))
 
 """
     tisa(t, T::Type)
+    tisa(t, Tspecified::Type, checkIsdefined::Bool = false)
 
 Compares the specified type with the type of an evaluated Token
+
+If you set checkIsdefined to true, and t is not defined in the scope, it returns undef.
 
 # Examples
 ```julia
@@ -140,7 +155,7 @@ julia> tisa(t, DataType)
 true
 ```
 """
-tisa(t::T, Tspecified::Type) where {T <: Union{Token, Array{Token}}} = isa(teval(t), Tspecified)
+tisa(t::T, Tspecified::Type, checkIsdefined::Bool = false) where {T <: Union{Token, Array{Token}}} = isa(teval(t, checkIsdefined), Tspecified)
 
 startpos(t::AbstractToken) = t.startpos
 endpos(t::AbstractToken) = t.endpos

--- a/src/token.jl
+++ b/src/token.jl
@@ -101,6 +101,31 @@ Meta.parse(t::T) where {T <: Union{Token, Array{Token}}} = Meta.parse(untokenize
 """
     teval(t)
     teval(t, checkIsdefined::Bool=false)
+    tgetfield(t::T)
+    tgetfield(t::T, checkIsdefined::Bool=false)
+    tgetfield(Module = @__MODULE__, t::T, checkIsdefined::Bool=false)
+
+Parses and evaluates a Token (get an instance). Similar to eval, but much faster.
+
+If you set checkIsdefined to true, and t is not defined in the scope it returns undef instead of throwing an error.
+
+# Examples
+```julia
+julia> t = collect(tokenize("Int64"))
+
+julia> tgetfield(t)
+Int64
+```
+"""
+function tgetfield(Module, t::T, checkIsdefined::Bool = false) where {T <: Union{Token, Array{Token}}}
+    pt = Meta.parse(t)
+    if checkIsdefined && !(isdefined(Module,pt))
+        return undef
+    end
+    return getfield(Module,pt)
+end
+
+tgetfield(t::T, checkIsdefined::Bool = false) where {T <: Union{Token, Array{Token}}} = tgetfield(@__MODULE__, t, checkIsdefined)
 
 Parses and evaluates a Token.
 

--- a/src/token_kinds.jl
+++ b/src/token_kinds.jl
@@ -549,7 +549,7 @@
             DDOT, # ..
             LDOTS, # …
             TRICOLON, # ⁝
-            VDOTS, # ⋮ 
+            VDOTS, # ⋮
             DDOTS, # ⋱
             ADOTS, # ⋰
             CDOTS, # ⋯
@@ -1326,7 +1326,7 @@ const UNICODE_OPS = Dict{Char, Kind}(
 '⋅' => UNICODE_DOT,
 '…' => LDOTS,
 '⁝' => TRICOLON,
-'⋮' => VDOTS, 
+'⋮' => VDOTS,
 '⋱' => DDOTS,
 '⋰' => ADOTS,
 '⋯' => CDOTS)

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -344,7 +344,7 @@ end
 
 
 function optakessuffix(k)
-    (Tokens.begin_ops < k < Tokens.end_ops) && 
+    (Tokens.begin_ops < k < Tokens.end_ops) &&
     !(k == Tokens.DDDOT ||
     Tokens.EQ <= k <= k == Tokens.XOR_EQ ||
     k == Tokens.CONDITIONAL ||
@@ -367,7 +367,7 @@ function optakessuffix(k)
     k == Tokens.TRANSPOSE ||
     k == Tokens.ANON_FUNC ||
     Tokens.NOT_SIGN <= k <= Tokens.QUAD_ROOT
-    ) 
+    )
 end
 
 function is_operator_start_char(c::Char)

--- a/test/lexer.jl
+++ b/test/lexer.jl
@@ -561,11 +561,13 @@ end
 
 @testset "evaluated tokens utilities" begin
     t1 = collect(tokenize("Int64"))[1]
+    @test Tokenize.Tokens.tgetfield(t1) == Int64
     @test Tokenize.Tokens.teval(t1) == Int64
     @test Tokenize.Tokens.ttypeof(t1) == DataType
     @test Tokenize.Tokens.tisa(t1, DataType) == true
 
     t2 = collect(tokenize("[5]"))
+    @test Tokenize.Tokens.tgetfield(t2) == [5]
     @test Tokenize.Tokens.teval(t2) == [5]
     @test Tokenize.Tokens.ttypeof(t2) == Array{Int64,1}
     @test Tokenize.Tokens.tisa(t2, Array{Int64}) == true

--- a/test/lexer.jl
+++ b/test/lexer.jl
@@ -561,13 +561,14 @@ end
 
 @testset "evaluated tokens utilities" begin
     t1 = collect(tokenize("Int64"))[1]
+    @test Tokenize.Tokens.tevalfast(t1) == Int64
     @test Tokenize.Tokens.tgetfield(t1) == Int64
     @test Tokenize.Tokens.teval(t1) == Int64
     @test Tokenize.Tokens.ttypeof(t1) == DataType
     @test Tokenize.Tokens.tisa(t1, DataType) == true
 
     t2 = collect(tokenize("[5]"))
-    @test Tokenize.Tokens.tgetfield(t2) == [5]
+    @test Tokenize.Tokens.tevalfast(t1) == [5]
     @test Tokenize.Tokens.teval(t2) == [5]
     @test Tokenize.Tokens.ttypeof(t2) == Array{Int64,1}
     @test Tokenize.Tokens.tisa(t2, Array{Int64}) == true

--- a/test/lexer.jl
+++ b/test/lexer.jl
@@ -560,8 +560,13 @@ end
 
 
 @testset "evaluated tokens utilities" begin
-    t = collect(tokenize("Int64"))[1]
-    @test Tokenize.Tokens.teval(t) == Int64
-    @test Tokenize.Tokens.ttypeof(t) == DataType
-    @test Tokenize.Tokens.tisa(t, DataType) == true
+    t1 = collect(tokenize("Int64"))[1]
+    @test Tokenize.Tokens.teval(t1) == Int64
+    @test Tokenize.Tokens.ttypeof(t1) == DataType
+    @test Tokenize.Tokens.tisa(t1, DataType) == true
+
+    t2 = collect(tokenize("[5]"))
+    @test Tokenize.Tokens.teval(t2) == [5]
+    @test Tokenize.Tokens.ttypeof(t2) == Array{Int64,1}
+    @test Tokenize.Tokens.tisa(t2, Array{Int64}) == true
 end

--- a/test/lexer.jl
+++ b/test/lexer.jl
@@ -559,3 +559,7 @@ end
 end
 
 
+@testset "evaluated tokens utilities" begin
+    t = collect(tokenize("Int64"))[1]
+    @test Tokenize.Tokens.teval(t) == Int64
+end

--- a/test/lexer.jl
+++ b/test/lexer.jl
@@ -563,4 +563,5 @@ end
     t = collect(tokenize("Int64"))[1]
     @test Tokenize.Tokens.teval(t) == Int64
     @test Tokenize.Tokens.ttypeof(t) == DataType
+    @test Tokenize.Tokens.tisa(t, DataType) == true
 end

--- a/test/lexer.jl
+++ b/test/lexer.jl
@@ -562,4 +562,5 @@ end
 @testset "evaluated tokens utilities" begin
     t = collect(tokenize("Int64"))[1]
     @test Tokenize.Tokens.teval(t) == Int64
+    @test Tokenize.Tokens.ttypeof(t) == DataType
 end

--- a/test/lexer.jl
+++ b/test/lexer.jl
@@ -269,7 +269,7 @@ end
                     "type",
                     "using",
                     "while"]
-                    
+
         @test T.kind(tok(kw)) == T.KEYWORD
     end
 end
@@ -513,11 +513,11 @@ for op in ops
 end
 end
 
-@testset "perp" begin 
-    @test tok("1 ⟂ 2", 3).kind==T.PERP 
+@testset "perp" begin
+    @test tok("1 ⟂ 2", 3).kind==T.PERP
 end
 
-@testset "outer" begin 
+@testset "outer" begin
     @test tok("outer", 1).kind==T.OUTER
 end
 
@@ -537,23 +537,23 @@ end
     @test tok("1**2",2).token_error === Tokens.INVALID_OPERATOR
 end
 
-@testset "hat suffix" begin 
+@testset "hat suffix" begin
     @test tok("ŝ", 1).kind==Tokens.IDENTIFIER
     @test untokenize(collect(tokenize("ŝ", Tokens.RawToken))[1], "ŝ") == "ŝ"
 end
 
-@testset "suffixed op" begin 
+@testset "suffixed op" begin
     s = "+¹"
     @test Tokens.isoperator(tok(s, 1).kind)
     @test untokenize(collect(tokenize(s, Tokens.RawToken))[1], s) == s
 end
 
-@testset "invalid float juxt" begin 
+@testset "invalid float juxt" begin
     s = "1.+2"
     @test tok(s, 1).kind == Tokens.ERROR
-    @test Tokens.isoperator(tok(s, 2).kind) 
+    @test Tokens.isoperator(tok(s, 2).kind)
     @test (t->t.val=="1234."    && t.kind == Tokens.ERROR )(tok("1234.+1")) # requires space before '.'
-    @test tok("1.+ ").kind == Tokens.ERROR 
+    @test tok("1.+ ").kind == Tokens.ERROR
     @test tok("1.⤋").kind  == Tokens.ERROR
     @test tok("1.?").kind == Tokens.ERROR
 end

--- a/test/lexer.jl
+++ b/test/lexer.jl
@@ -568,7 +568,7 @@ end
     @test Tokenize.Tokens.tisa(t1, DataType) == true
 
     t2 = collect(tokenize("[5]"))
-    @test Tokenize.Tokens.tevalfast(t1) == [5]
+    @test Tokenize.Tokens.tevalfast(t2) == [5]
     @test Tokenize.Tokens.teval(t2) == [5]
     @test Tokenize.Tokens.ttypeof(t2) == Array{Int64,1}
     @test Tokenize.Tokens.tisa(t2, Array{Int64}) == true


### PR DESCRIPTION
Introducing three new functions
```julia
tevalfast(t)                 # Parses and evaluates a Token. Uses `tgetfield(t)`, `teval(t)`, `evalfast(t)`
tisdefined(t)                # Check if a `Token` that represent a `Symbol` is defined.
ttypeof(t)                   # Returns the type of an evaluated Token
tisa(t)                      # Compares the specified type with the type of an evaluated Token
```
Extending Meta.parse to support `Token` and `Array{Token}`.