### PR TITLE
RFC: change optimization level to 1

### DIFF
--- a/src/Tokenize.jl
+++ b/src/Tokenize.jl
@@ -1,5 +1,9 @@
 module Tokenize
 
+if isdefined(Base, :Experimental) && isdefined(Base.Experimental, Symbol("@optlevel"))
+    @eval Base.Experimental.@optlevel 1
+end
+
 include("token.jl")
 include("lexer.jl")
 


### PR DESCRIPTION
This package has a fairly hefty latency:

```jl
julia> @time @eval collect(tokenize("foo"));
  1.138432 seconds (106.97 k allocations: 5.341 MiB, 99.99% compilation time)
```

Profiling a bit, it looks like a lot of this is spent inside LLVM. Taking down the optimization level to 1, gives:

```jl
julia> @time @eval collect(tokenize("foo"));
  0.559139 seconds (106.97 k allocations: 5.341 MiB, 99.98% compilation time)
```

Looking at the benchmark, we now have:

```jl
julia> include("../benchmark/lex_base.jl")
Lexed 200 files, with a total of 775675 tokens with 0 errors
Time Token: 0.1065 seconds
Time RawToken: 0.0437 seconds
```

while with this PR we have:

```jl
julia> include("../benchmark/lex_base.jl")
Lexed 200 files, with a total of 775675 tokens with 0 errors
Time Token: 0.1433 seconds
Time RawToken: 0.0659 seconds
``` 

so there is some slowdown. However, in order for this slowdown to dominate the improved load time you have to lex quite a lot of files. I believe that in the majority of cases this will be a performance win overall. It is also quite rare for the lexing to be dominating the cost of your process, typically what you end up doing with the tokens (e.g. parsing) will take significantly more time.

Thoughts @pfitzseb, @ZacLN ?