### PR TITLE
Simplify lex_identifier

### DIFF
--- a/src/_precompile.jl
+++ b/src/_precompile.jl
@@ -48,14 +48,6 @@ function _precompile_()
     precompile(Tokenize.Lexers.start_token!, (Tokenize.Lexers.Lexer{GenericIOBuffer{Array{UInt8, 1}},Tokenize.Tokens.Token},))
     precompile(Tokenize.Lexers.start_token!, (Tokenize.Lexers.Lexer{GenericIOBuffer{Array{UInt8, 1}},Tokenize.Tokens.RawToken},))
 
-    precompile(Tokenize.Lexers.tryread, (Tokenize.Lexers.Lexer{GenericIOBuffer{Array{UInt8, 1}},Tokenize.Tokens.Token}, Tuple{Char}, Tokenize.Tokens.Kind,Char))
-    precompile(Tokenize.Lexers.tryread, (Tokenize.Lexers.Lexer{GenericIOBuffer{Array{UInt8, 1}},Tokenize.Tokens.Token}, Tuple{Char,Char}, Tokenize.Tokens.Kind,Char))
-    precompile(Tokenize.Lexers.tryread, (Tokenize.Lexers.Lexer{GenericIOBuffer{Array{UInt8, 1}},Tokenize.Tokens.Token}, Tuple{Char,Char,Char}, Tokenize.Tokens.Kind,Char))
-    precompile(Tokenize.Lexers.tryread, (Tokenize.Lexers.Lexer{GenericIOBuffer{Array{UInt8, 1}},Tokenize.Tokens.Token}, Tuple{Char,Char,Char,Char}, Tokenize.Tokens.Kind,Char))
-    precompile(Tokenize.Lexers.tryread, (Tokenize.Lexers.Lexer{GenericIOBuffer{Array{UInt8, 1}},Tokenize.Tokens.Token}, Tuple{Char,Char,Char,Char,Char}, Tokenize.Tokens.Kind,Char))
-    precompile(Tokenize.Lexers.tryread, (Tokenize.Lexers.Lexer{GenericIOBuffer{Array{UInt8, 1}},Tokenize.Tokens.Token}, Tuple{Char,Char,Char,Char,Char,Char}, Tokenize.Tokens.Kind,Char))
-    precompile(Tokenize.Lexers.tryread, (Tokenize.Lexers.Lexer{GenericIOBuffer{Array{UInt8, 1}},Tokenize.Tokens.Token}, Tuple{Char,Char,Char,Char,Char,Char,Char}, Tokenize.Tokens.Kind,Char))
-    precompile(Tokenize.Lexers.tryread, (Tokenize.Lexers.Lexer{GenericIOBuffer{Array{UInt8, 1}},Tokenize.Tokens.Token}, Tuple{Char,Char,Char,Char,Char,Char,Char,Char}, Tokenize.Tokens.Kind,Char))
 
 
     precompile(Tokenize.Lexers.lex_greater, (Tokenize.Lexers.Lexer{GenericIOBuffer{Array{UInt8, 1}},Tokenize.Tokens.Token},))
@@ -85,7 +77,6 @@ function _precompile_()
 
     precompile(Tokenize.Lexers.lex_whitespace, (Tokenize.Lexers.Lexer{GenericIOBuffer{Array{UInt8, 1}},Tokenize.Tokens.Token},))
     precompile(Tokenize.Lexers.read_string, (Tokenize.Lexers.Lexer{GenericIOBuffer{Array{UInt8, 1}},Tokenize.Tokens.Token}, Tokenize.Tokens.Kind,))
-    precompile(Tokenize.Lexers.readrest, (Tokenize.Lexers.Lexer{GenericIOBuffer{Array{UInt8, 1}},Tokenize.Tokens.Token},Char))
 
     precompile(Tokenize.Lexers.accept, (Tokenize.Lexers.Lexer{GenericIOBuffer{Array{UInt8, 1}},Tokenize.Tokens.Token}, Char,))
     precompile(Tokenize.Lexers.accept, (Tokenize.Lexers.Lexer{GenericIOBuffer{Array{UInt8, 1}},Tokenize.Tokens.Token}, String,))
@@ -95,13 +86,10 @@ function _precompile_()
     precompile(Tokenize.Lexers.accept, (Tokenize.Lexers.Lexer{GenericIOBuffer{Array{UInt8, 1}},Tokenize.Tokens.Token},typeof(Tokenize.Lexers.ishex),))
     precompile(Tokenize.Lexers.accept_batch, (Tokenize.Lexers.Lexer{GenericIOBuffer{Array{UInt8, 1}},Tokenize.Tokens.Token}, typeof(Tokenize.Lexers.iswhitespace),))
     precompile(Tokenize.Lexers.accept_batch, (Tokenize.Lexers.Lexer{GenericIOBuffer{Array{UInt8, 1}},Tokenize.Tokens.Token}, typeof(Tokenize.Lexers.isdigit),))
-    precompile(Tokenize.Lexers._doret, (Char, Tokenize.Lexers.Lexer{GenericIOBuffer{Array{UInt8, 1}},Tokenize.Tokens.Token},))
-    precompile(Tokenize.Lexers._doret, (Char, Tokenize.Lexers.Lexer{GenericIOBuffer{Array{UInt8, 1}},Tokenize.Tokens.RawToken},))
 
     precompile(Tokenize.Lexers.accept_batch, (Tokenize.Lexers.Lexer{GenericIOBuffer{Array{UInt8, 1}},Tokenize.Tokens.RawToken}, typeof(Tokenize.Lexers.iswhitespace),))
     precompile(Tokenize.Lexers.accept_batch, (Tokenize.Lexers.Lexer{GenericIOBuffer{Array{UInt8, 1}},Tokenize.Tokens.RawToken}, typeof(Tokenize.Lexers.isdigit),))
     precompile(Tokenize.Lexers.accept, (Tokenize.Lexers.Lexer{GenericIOBuffer{Array{UInt8, 1}},Tokenize.Tokens.RawToken}, Char,))
-    precompile(Tokenize.Lexers.accept, (Tokenize.Lexers.Lexer{GenericIOBuffer{Array{UInt8, 1}},Tokenize.Tokens.RawToken}, Function,))
 
 
     precompile(Tokenize.Lexers.readchar, (GenericIOBuffer{Array{UInt8, 1}},))    

--- a/src/lexer.jl
+++ b/src/lexer.jl
@@ -408,7 +408,6 @@ function next_token(l::Lexer, start = true)
         readon(l)
         return lex_cmd(l);
     elseif is_identifier_start_char(c)
-        readon(l)
         return lex_identifier(l, c)
     elseif isdigit(c)
         readon(l)
@@ -1024,305 +1023,83 @@ function lex_cmd(l::Lexer, doemit=true)
     end
 end
 
-function tryread(l, str, k, c)
-    for s in str
-        c = peekchar(l)
-        if c != s
-            if !is_identifier_char(c)
-                return emit(l, IDENTIFIER)
-            end
-            return readrest(l, c)
-        else
-            readchar(l)
-        end
+function lex_identifier(l::Lexer{IO_t,T}, c) where {IO_t,T}
+    if T == Token
+        readon(l)
     end
-    if is_identifier_char(peekchar(l))
-        return readrest(l, c)
-    end
-    return emit(l, k)
-end
-
-function readrest(l, c)
+    cnt = 1
+    h = simple_hash(Int(c), cnt, 0)
     while true
         pc, ppc = dpeekchar(l)
         if !is_identifier_char(pc) || (pc == '!' && ppc == '=')
             break
         end
         c = readchar(l)
+        cnt += 1
+        h = simple_hash(Int(c), cnt, h)
     end
 
-    return emit(l, IDENTIFIER)
+    return emit(l, get(kw_hash, h, IDENTIFIER))
 end
 
+function simple_hash(c, cnt, h)
+    h = h*c + c + cnt
+end
 
-function _doret(l, c)
-    if !is_identifier_char(c)
-        return emit(l, IDENTIFIER)
-    else
-        return readrest(l, c)
+function simple_hash(str)
+    ind = 1
+    cnt = 1
+    h = 0
+    while ind <= length(str)
+        h = simple_hash(Int(str[ind]), cnt, h)
+        cnt += 1
+        ind = nextind(str, ind)
     end
+    h
 end
 
-function lex_identifier(l, c)
-    if c == 'a'
-        return tryread(l, ('b', 's', 't', 'r', 'a', 'c', 't'), ABSTRACT, c)
-    elseif c == 'b'
-        c = peekchar(l)
-        if c == 'a'
-            c = readchar(l)
-            return tryread(l, ('r', 'e', 'm', 'o', 'd', 'u', 'l', 'e'), BAREMODULE, c)
-        elseif c == 'e'
-            c = readchar(l)
-            return tryread(l, ('g', 'i', 'n'), BEGIN, c)
-        elseif c == 'r'
-            c = readchar(l)
-            return tryread(l, ('e', 'a', 'k'), BREAK, c)
-        else
-            return _doret(l, c)
-        end
-    elseif c == 'c'
-        c = peekchar(l)
-        if c == 'a'
-            c = readchar(l)
-            return tryread(l, ('t', 'c', 'h'), CATCH, c)
-        elseif c == 'o'
-            readchar(l)
-            c = peekchar(l)
-            if c == 'n'
-                readchar(l)
-                c = peekchar(l)
-                if c == 's'
-                    readchar(l)
-                    c = peekchar(l)
-                    return tryread(l, ('t',), CONST, c)
-                elseif c == 't'
-                    readchar(l)
-                    c = peekchar(l)
-                    return tryread(l, ('i', 'n', 'u', 'e'), CONTINUE, c)
-                else
-                    return _doret(l, c)
-                end
-            else
-                return _doret(l, c)
-            end
-        else
-            return _doret(l, c)
-        end
-    elseif c == 'd'
-        return tryread(l, ('o'), DO, c)
-    elseif c == 'e'
-        c = peekchar(l)
-        if c == 'l'
-            readchar(l)
-            c = peekchar(l)
-            if c == 's'
-                readchar(l)
-                c = peekchar(l)
-                if c == 'e'
-                    readchar(l)
-                    c = peekchar(l)
-                    if !is_identifier_char(c)
-                        return emit(l, ELSE)
-                    elseif c == 'i'
-                        c = readchar(l)
-                        return tryread(l, ('f'), ELSEIF ,c)
-                    else
-                        return _doret(l, c)
-                    end
-                else
-                    return _doret(l, c)
-                end
-            else
-                return _doret(l, c)
-            end
-        elseif c == 'n'
-            c = readchar(l)
-            return tryread(l, ('d'), END, c)
-        elseif c == 'x'
-            c = readchar(l)
-            return tryread(l, ('p', 'o', 'r', 't'), EXPORT, c)
-        else
-            return _doret(l, c)
-        end
-    elseif c == 'f'
-        c = peekchar(l)
-        if c == 'a'
-            c = readchar(l)
-            return tryread(l, ('l', 's', 'e'), FALSE, c)
-        elseif c == 'i'
-            c = readchar(l)
-            return tryread(l, ('n', 'a', 'l', 'l', 'y'), FINALLY, c)
-        elseif c == 'o'
-            c = readchar(l)
-            return tryread(l, ('r'), FOR, c)
-        elseif c == 'u'
-            c = readchar(l)
-            return tryread(l, ('n', 'c', 't', 'i', 'o', 'n'), FUNCTION, c)
-        else
-            return _doret(l, c)
-        end
-    elseif c == 'g'
-        return tryread(l, ('l', 'o', 'b', 'a', 'l'), GLOBAL, c)
-    elseif c == 'i'
-        c = peekchar(l)
-        if c == 'f'
-            readchar(l)
-            c = peekchar(l)
-            if !is_identifier_char(c)
-                return emit(l, IF)
-            else
-                return readrest(l, c)
-            end
-        elseif c == 'm'
-            readchar(l)
-            c = peekchar(l)
-            if c == 'p'
-                readchar(l)
-                c = peekchar(l)
-                if c == 'o'
-                    readchar(l)
-                    c = peekchar(l)
-                    if c == 'r'
-                        readchar(l)
-                        c = peekchar(l)
-                        if c == 't'
-                            readchar(l)
-                            c = peekchar(l)
-                            if !is_identifier_char(c)
-                                return emit(l, IMPORT)
-                            elseif c == 'a'
-                                c = readchar(l)
-                                return tryread(l, ('l','l'), IMPORTALL, c)
-                            else
-                                return _doret(l, c)
-                            end
-                        else
-                            return _doret(l, c)
-                        end
-                    else
-                        return _doret(l, c)
-                    end
-                else
-                    return _doret(l, c)
-                end
-            else
-                return _doret(l, c)
-            end
-        elseif c == 'n'
-            readchar(l)
-            c = peekchar(l)
-            if !is_identifier_char(c)
-                return emit(l, IN)
-            else
-                return readrest(l, c)
-            end
-        elseif (@static VERSION >= v"0.6.0-dev.1471" ? true : false) && c == 's'
-            c = readchar(l)
-            return tryread(l, ('a'), ISA, c)
-        else
-            return _doret(l, c)
-        end
-    elseif c == 'l'
-        c = peekchar(l)
-        if c == 'e'
-            readchar(l)
-            return tryread(l, ('t'), LET, c)
-        elseif c == 'o'
-            readchar(l)
-            return tryread(l, ('c', 'a', 'l'), LOCAL, c)
-        else
-            return _doret(l, c)
-        end
-    elseif c == 'm'
-        c = peekchar(l)
-        if c == 'a'
-            c = readchar(l)
-            return tryread(l, ('c', 'r', 'o'), MACRO, c)
-        elseif c == 'o'
-            c = readchar(l)
-            return tryread(l, ('d', 'u', 'l', 'e'), MODULE, c)
-        elseif c == 'u'
-            c = readchar(l)
-            return tryread(l, ('t', 'a', 'b', 'l', 'e'), MUTABLE, c)
-        else
-            return _doret(l, c)
-        end
-    elseif c == 'o'
-        return tryread(l, ('u', 't', 'e', 'r'), OUTER, c)
-    elseif c == 'p'
-        return tryread(l, ('r', 'i', 'm', 'i', 't', 'i', 'v', 'e'), PRIMITIVE, c)
-    elseif c == 'q'
-        return tryread(l, ('u', 'o', 't', 'e'), QUOTE, c)
-    elseif c == 'r'
-        return tryread(l, ('e', 't', 'u', 'r', 'n'), RETURN, c)
-    elseif c == 's'
-        return tryread(l, ('t', 'r', 'u', 'c', 't'), STRUCT, c)
-    elseif c == 't'
-        c = peekchar(l)
-        if c == 'r'
-            readchar(l)
-            c = peekchar(l)
-            if c == 'u'
-                c = readchar(l)
-                return tryread(l, ('e'), TRUE, c)
-            elseif c == 'y'
-                readchar(l)
-                c = peekchar(l)
-                if !is_identifier_char(c)
-                    return emit(l, TRY)
-                else
-                    c = readchar(l)
-                    return _doret(l, c)
-                end
-            else
-                return _doret(l, c)
-            end
-        elseif c == 'y'
-            readchar(l)
-            c = peekchar(l)
-            if c == 'p'
-                readchar(l)
-                c = peekchar(l)
-                if c == 'e'
-                    readchar(l)
-                    c = peekchar(l)
-                    if !is_identifier_char(c)
-                        return emit(l, TYPE)
-                    else
-                        c = readchar(l)
-                        return _doret(l, c)
-                    end
-                else
-                    return _doret(l, c)
-                end
-            else
-                return _doret(l, c)
-            end
-        else
-            return _doret(l, c)
-        end
-    elseif c == 'u'
-        return tryread(l, ('s', 'i', 'n', 'g'), USING, c)
-    elseif c == 'w'
-        c = peekchar(l)
-        if c == 'h'
-            readchar(l)
-            c = peekchar(l)
-            if c == 'e'
-                c = readchar(l)
-                return tryread(l, ('r', 'e'), WHERE, c)
-            elseif c == 'i'
-                c = readchar(l)
-                return tryread(l, ('l', 'e'), WHILE, c)
-            else
-                return _doret(l, c)
-            end
-        else
-            return _doret(l, c)
-        end
-    else
-        return _doret(l, c)
-    end
-end
+kws = [
+Tokens.ABSTRACT,
+Tokens.BAREMODULE,
+Tokens.BEGIN,
+Tokens.BREAK,
+Tokens.CATCH,
+Tokens.CONST,
+Tokens.CONTINUE,
+Tokens.DO,
+Tokens.ELSE,
+Tokens.ELSEIF,
+Tokens.END,
+Tokens.EXPORT,
+Tokens.FINALLY,
+Tokens.FOR,
+Tokens.FUNCTION,
+Tokens.GLOBAL,
+Tokens.IF,
+Tokens.IMPORT,
+Tokens.IMPORTALL,
+Tokens.LET,
+Tokens.LOCAL,
+Tokens.MACRO,
+Tokens.MODULE,
+Tokens.MUTABLE,
+Tokens.NEW,
+Tokens.OUTER,
+Tokens.PRIMITIVE,
+Tokens.QUOTE,
+Tokens.RETURN,
+Tokens.STRUCT,
+Tokens.TRY,
+Tokens.TYPE,
+Tokens.USING,
+Tokens.WHILE,
+Tokens.IN,
+Tokens.ISA,
+Tokens.WHERE,
+Tokens.TRUE,
+Tokens.FALSE,
+]
+
+const kw_hash = Dict(simple_hash(lowercase(string(kw))) => kw for kw in kws)
 
 end # module

--- a/src/lexer.jl
+++ b/src/lexer.jl
@@ -416,6 +416,7 @@ end
 
 # Lex whitespace, a whitespace char has been consumed
 function lex_whitespace(l::Lexer)
+    readon(l)
     accept_batch(l, iswhitespace)
     return emit(l, Tokens.WHITESPACE)
 end

--- a/src/lexer.jl
+++ b/src/lexer.jl
@@ -460,80 +460,63 @@ end
 
 # Lex a greater char, a '>' has been consumed
 function lex_greater(l::Lexer)
-    pc, ppc = dpeekchar(l)
-    if pc === '>' && ppc === '>'
-        readchar(l)
-        readchar(l)
-        if peekchar(l) === '='
-            readchar(l)
-            emit(l, Tokens.UNSIGNED_BITSHIFT_EQ)
-        else
-            emit(l, Tokens.UNSIGNED_BITSHIFT)
+    if accept(l, '>') # >>
+        if accept(l, '>') # >>>
+            if accept(l, '=') # >>>=
+                return emit(l, Tokens.UNSIGNED_BITSHIFT_EQ)
+            else # >>>?, ? not a =
+                return emit(l, Tokens.UNSIGNED_BITSHIFT)
+            end
+        elseif accept(l, '=') # >>=
+            return emit(l, Tokens.RBITSHIFT_EQ)
+        else # '>>'
+            return emit(l, Tokens.RBITSHIFT)
         end
-    elseif pc === '>' && ppc === '='
-        readchar(l)
-        readchar(l)
-        emit(l, Tokens.RBITSHIFT_EQ)
-    elseif pc === '>'
-        readchar(l)
-        emit(l, Tokens.RBITSHIFT)
-    elseif pc === '='
-        readchar(l)
-        emit(l, Tokens.GREATER_EQ)
-    elseif pc === ':'
-        readchar(l)
-        emit(l, Tokens.ISSUPERTYPE)
-    else
-        emit(l, Tokens.GREATER)
+    elseif accept(l, '=') # >=
+        return emit(l, Tokens.GREATER_EQ)
+    elseif accept(l, ':') # >:
+        return emit(l, Tokens.ISSUPERTYPE)
+    else  # '>'
+        return emit(l, Tokens.GREATER)
     end
 end
 
 # Lex a less char, a '<' has been consumed
 function lex_less(l::Lexer)
-    pc, ppc = dpeekchar(l)
-    if pc === '<' && ppc === '='
-        readchar(l)
-        readchar(l)
-        emit(l, Tokens.LBITSHIFT_EQ)
-    elseif pc === '<'
-        readchar(l)
-        emit(l, Tokens.LBITSHIFT)
-    elseif pc === '='
-        readchar(l)
-        emit(l, Tokens.LESS_EQ)
-    elseif pc === ':'
-        readchar(l)
-        emit(l, Tokens.ISSUBTYPE)
-    elseif pc === '|'
-        readchar(l)
-        emit(l, Tokens.LPIPE)
-    elseif pc === '-' && ppc === '-'
-        readchar(l)
-        readchar(l)
-        if peekchar(l) === '>'
-            readchar(l)
-            emit(l, Tokens.DOUBLE_ARROW)
+    if accept(l, '<') # <<
+        if accept(l, '=') # <<=
+            return emit(l, Tokens.LBITSHIFT_EQ)
+        else # '<<?', ? not =, ' '
+            return emit(l, Tokens.LBITSHIFT)
+        end
+    elseif accept(l, '=') # <=
+        return emit(l, Tokens.LESS_EQ)
+    elseif accept(l, ':')
+        return emit(l, Tokens.ISSUBTYPE)
+    elseif accept(l, '|') # <|
+        return emit(l, Tokens.LPIPE)
+    elseif dpeekchar(l) == ('-', '-') # <-- or <-->
+        readchar(l); readchar(l)
+        if accept(l, '>')
+            return emit(l, Tokens.DOUBLE_ARROW)
         else
-            emit(l, Tokens.LEFT_ARROW)
+            return emit(l, Tokens.LEFT_ARROW)
         end
     else
-        emit(l, Tokens.LESS) # '<'
+        return emit(l, Tokens.LESS) # '<'
     end
 end
 
 # Lex all tokens that start with an = character.
 # An '=' char has been consumed
 function lex_equal(l::Lexer)
-    pc, ppc = dpeekchar(l)
-    if pc === '=' && ppc === '='
-        readchar(l)
-        readchar(l)
-        emit(l, Tokens.EQEQEQ)
-    elseif pc === '='
-        readchar(l)
-        emit(l, Tokens.EQEQ)
-    elseif pc === '>'
-        readchar(l)
+    if accept(l, '=') # ==
+        if accept(l, '=') # ===
+            emit(l, Tokens.EQEQEQ)
+        else
+            emit(l, Tokens.EQEQ)
+        end
+    elseif accept(l, '>') # =>
         emit(l, Tokens.PAIR_ARROW)
     else
         emit(l, Tokens.EQ)
@@ -542,106 +525,78 @@ end
 
 # Lex a colon, a ':' has been consumed
 function lex_colon(l::Lexer)
-    pc = peekchar(l)
-    if pc === ':'
-        readchar(l)
-        emit(l, Tokens.DECLARATION)
-    elseif pc === '='
-        readchar(l)
-        emit(l, Tokens.COLON_EQ)
+    if accept(l, ':') # '::'
+        return emit(l, Tokens.DECLARATION)
+    elseif accept(l, '=') # ':='
+        return emit(l, Tokens.COLON_EQ)
     else
-        emit(l, Tokens.COLON)
+        return emit(l, Tokens.COLON)
     end
 end
 
 function lex_exclaim(l::Lexer)
-    pc, ppc = dpeekchar(l)
-    if pc === '=' && ppc === '='
-        readchar(l)
-        readchar(l)
-        emit(l, Tokens.NOT_IS)
-    elseif pc === '='
-        readchar(l)
-        emit(l, Tokens.NOT_EQ)
+    if accept(l, '=') # !=
+        if accept(l, '=') # !==
+            return emit(l, Tokens.NOT_IS)
+        else # !=
+            return emit(l, Tokens.NOT_EQ)
+        end
     else
-        emit(l, Tokens.NOT)
+        return emit(l, Tokens.NOT)
     end
 end
 
 function lex_percent(l::Lexer)
-    if peekchar(l) === '='
-        readchar(l)
-        emit(l, Tokens.REM_EQ)
+    if accept(l, '=')
+        return emit(l, Tokens.REM_EQ)
     else
-        emit(l, Tokens.REM)
+        return emit(l, Tokens.REM)
     end
-    # if accept(l, '=')
-    #     return emit(l, Tokens.REM_EQ)
-    # else
-    #     return emit(l, Tokens.REM)
-    # end
 end
 
 function lex_bar(l::Lexer)
-    pc = peekchar(l)
-    if pc === '='
-        readchar(l)
-        emit(l, Tokens.OR_EQ)
-    elseif pc === '>'
-        readchar(l)
-        emit(l, Tokens.RPIPE)
-    elseif pc === '|'
-        readchar(l)
-        emit(l, Tokens.LAZY_OR)
+    if accept(l, '=') # |=
+        return emit(l, Tokens.OR_EQ)
+    elseif accept(l, '>') # |>
+        return emit(l, Tokens.RPIPE)
+    elseif accept(l, '|') # ||
+        return emit(l, Tokens.LAZY_OR)
     else
-        emit(l, Tokens.OR)
+        emit(l, Tokens.OR) # '|'
     end
 end
 
 function lex_plus(l::Lexer)
-    pc = peekchar(l)
-    if pc === '+'
-        readchar(l)
-        emit(l, Tokens.PLUSPLUS)
-    elseif pc === '='
-        readchar(l)
-        emit(l, Tokens.PLUS_EQ)
-    else
-        emit(l, Tokens.PLUS)
+    if accept(l, '+')
+        return emit(l, Tokens.PLUSPLUS)
+    elseif accept(l, '=')
+        return emit(l, Tokens.PLUS_EQ)
     end
+    return emit(l, Tokens.PLUS)
 end
 
 function lex_minus(l::Lexer)
-    pc, ppc = dpeekchar(l)
-    if pc === '-' && ppc === '>'
-        readchar(l)
-        readchar(l)
-        emit(l, Tokens.RIGHT_ARROW)
-    elseif pc === '-'
-        readchar(l)
-        emit_error(l, Tokens.INVALID_OPERATOR) # "--" is an invalid operator
-    elseif pc === '>'
-        readchar(l)
-        emit(l, Tokens.ANON_FUNC)
-    elseif pc === '='
-        readchar(l)
-        emit(l, Tokens.MINUS_EQ)
-    else
-        emit(l, Tokens.MINUS)
+    if accept(l, '-')
+        if accept(l, '>')
+            return emit(l, Tokens.RIGHT_ARROW)
+        else
+            return emit_error(l, Tokens.INVALID_OPERATOR) # "--" is an invalid operator
+        end
+    elseif accept(l, '>')
+        return emit(l, Tokens.ANON_FUNC)
+    elseif accept(l, '=')
+        return emit(l, Tokens.MINUS_EQ)
     end
+    return emit(l, Tokens.MINUS)
 end
 
 function lex_star(l::Lexer)
-    pc = peekchar(l)
-    if pc === '*'
-        readchar(l)
-        emit_error(l, Tokens.INVALID_OPERATOR)
-    elseif pc === '='
-        readchar(l)
-        emit(l, Tokens.STAR_EQ)
-    else
-        emit(l, Tokens.STAR)
+    if accept(l, '*')
+        return emit_error(l, Tokens.INVALID_OPERATOR) # "**" is an invalid operator use ^
+    elseif accept(l, '=')
+        return emit(l, Tokens.STAR_EQ)
     end
+    return emit(l, Tokens.STAR)
 end
 
 function lex_circumflex(l::Lexer)
@@ -828,15 +783,12 @@ function lex_prime(l, doemit = true)
 end
 
 function lex_amper(l::Lexer)
-    pc = peekchar(l)
-    if pc === '&'
-        readchar(l)
-        emit(l, Tokens.LAZY_AND)
-    elseif pc === '='
-        readchar(l)
-        emit(l, Tokens.AND_EQ)
+    if accept(l, '&')
+        return emit(l, Tokens.LAZY_AND)
+    elseif accept(l, "=")
+        return emit(l, Tokens.AND_EQ)
     else
-        emit(l, Tokens.AND)
+        return emit(l, Tokens.AND)
     end
 end
 
@@ -926,19 +878,16 @@ end
 # Parse a token starting with a forward slash.
 # A '/' has been consumed
 function lex_forwardslash(l::Lexer)
-    pc, ppc = dpeekchar(l)
-    if pc === '/' && ppc === '='
-        readchar(l)
-        readchar(l)
-        emit(l, Tokens.FWDFWD_SLASH_EQ)
-    elseif pc === '/'
-        readchar(l)
-        emit(l, Tokens.FWDFWD_SLASH)
-    elseif pc === '='
-        readchar(l)
-        emit(l, Tokens.FWD_SLASH_EQ)
+    if accept(l, "/") # //
+        if accept(l, "=") # //=
+            return emit(l, Tokens.FWDFWD_SLASH_EQ)
+        else
+            return emit(l, Tokens.FWDFWD_SLASH)
+        end
+    elseif accept(l, "=") # /=
+        return emit(l, Tokens.FWD_SLASH_EQ)
     else
-        emit(l, Tokens.FWD_SLASH)
+        return emit(l, Tokens.FWD_SLASH)
     end
 end
 

--- a/src/lexer.jl
+++ b/src/lexer.jl
@@ -1028,7 +1028,7 @@ function lex_identifier(l::Lexer{IO_t,T}, c) where {IO_t,T}
         readon(l)
     end
     cnt = 1
-    h = simple_hash(Int(c), cnt, 0)
+    h = simple_hash(Int(c), cnt, 1)
     while true
         pc, ppc = dpeekchar(l)
         if !is_identifier_char(pc) || (pc == '!' && ppc == '=')
@@ -1049,7 +1049,7 @@ end
 function simple_hash(str)
     ind = 1
     cnt = 1
-    h = 0
+    h = 1
     while ind <= length(str)
         h = simple_hash(Int(str[ind]), cnt, h)
         cnt += 1
@@ -1083,7 +1083,6 @@ Tokens.LOCAL,
 Tokens.MACRO,
 Tokens.MODULE,
 Tokens.MUTABLE,
-Tokens.NEW,
 Tokens.OUTER,
 Tokens.PRIMITIVE,
 Tokens.QUOTE,


### PR DESCRIPTION
Alternative to https://github.com/JuliaLang/Tokenize.jl/pull/187. Simplifies (and speeds up?) lex_identifier by building a hash as each character of an identifier is read and then checking against a table of keywords/word-operators before emiting. However, I'm not sure about the validity of the `simple_hash` function I've used.

Seems to cut timings on the first run to a little more than half with a neglible impact on once-compiled run time for the test below
```julia
for i = 1:5
    run(`julia -e "using Tokenize;@time @eval collect(tokenize(\"foo + bar\"));@time @eval collect(tokenize(\"foo + bar\"));"`)
end
```