### PR TITLE
More unicode dots as operators

### DIFF
--- a/src/token_kinds.jl
+++ b/src/token_kinds.jl
@@ -666,8 +666,6 @@
             DIVISION_SIGN, # ÷
             REM, # %
             UNICODE_DOT, # ⋅
-            UNICODE_DOT2, # ·
-            UNICODE_DOT3, # ·
             RING_OPERATOR, # ∘
             MULTIPLICATION_SIGN, # ×
             BACKSLASH, # \
@@ -1368,9 +1366,9 @@ const UNICODE_OPS = Dict{Char, Kind}(
 '⥯' => DOWNWARDS_HARPOON_WITH_BARB_LEFT_BESIDE_UPWARDS_HARPOON_WITH_BARB_RIGHT,
 '￪' => HALFWIDTH_UPWARDS_ARROW,
 '￬' => HALFWIDTH_DOWNWARDS_ARROW,
+'·' => UNICODE_DOT,
+'·' => UNICODE_DOT,
 '⋅' => UNICODE_DOT,
-'·' => UNICODE_DOT2,
-'·' => UNICODE_DOT3,
 '…' => LDOTS,
 '⁝' => TRICOLON,
 '⋮' => VDOTS,
@@ -1483,6 +1481,7 @@ UNICODE_OPS_REVERSE[DDDOT] = :(...)
 UNICODE_OPS_REVERSE[TRANSPOSE] = Symbol(".'")
 UNICODE_OPS_REVERSE[ANON_FUNC] = :(->)
 UNICODE_OPS_REVERSE[WHERE] = :where
+UNICODE_OPS_REVERSE[UNICODE_DOT] = Symbol("⋅")
 if VERSION >= v"1.6"
     str = """
     begin

--- a/src/token_kinds.jl
+++ b/src/token_kinds.jl
@@ -666,6 +666,8 @@
             DIVISION_SIGN, # ÷
             REM, # %
             UNICODE_DOT, # ⋅
+            UNICODE_DOT2, # ·
+            UNICODE_DOT3, # ·
             RING_OPERATOR, # ∘
             MULTIPLICATION_SIGN, # ×
             BACKSLASH, # \
@@ -1367,6 +1369,8 @@ const UNICODE_OPS = Dict{Char, Kind}(
 '￪' => HALFWIDTH_UPWARDS_ARROW,
 '￬' => HALFWIDTH_DOWNWARDS_ARROW,
 '⋅' => UNICODE_DOT,
+'·' => UNICODE_DOT2,
+'·' => UNICODE_DOT3,
 '…' => LDOTS,
 '⁝' => TRICOLON,
 '⋮' => VDOTS,

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -131,7 +131,9 @@ readchar(io::IO) = eof(io) ? EOF_CHAR : read(io, Char)
     0x00002b30 <= c <= 0x00002b44 ||
     0x00002b47 <= c <= 0x00002b4c ||
     0x0000ffe9 <= c <= 0x0000ffec ||
-    0x00002aea <= c <= 0x00002aeb
+    0x00002aea <= c <= 0x00002aeb ||
+    c == 0x00000387 ||
+    c == 0x000000b7
 end
 
 function dotop2(pc, dpc)


### PR DESCRIPTION
Ref https://github.com/JuliaLang/julia/pull/25157

Should we normalize all of these to `UNICODE_DOT` here? Edit: Yes.

